### PR TITLE
_

### DIFF
--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -34,7 +34,7 @@ class RyzenthXAsync:
         self.headers = {"x-api-key": self.api_key}
         self.images = self.ImagesAsync(self)
         self.what = self.WhatAsync(self)
-        self.openai_audio = self.WhisperAsync(self)
+        self.openai_audio = WhisperAsync(self)
         self.obj = Box
 
     class WhatAsync:

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -34,7 +34,7 @@ class RyzenthXSync:
         self.headers = {"x-api-key": self.api_key}
         self.images = self.ImagesSync(self)
         self.what = self.WhatSync(self)
-        self.openai_audio = self.WhisperSync(self)
+        self.openai_audio = WhisperSync(self)
         self.obj = Box
 
     class WhatSync:


### PR DESCRIPTION
## Summary by Sourcery

Fix incorrect references to the Whisper audio client classes in both async and sync modules by removing the `self.` prefix in their initializations.

Bug Fixes:
- Reference the top-level `WhisperAsync` class instead of `self.WhisperAsync` in the async client initializer.
- Reference the top-level `WhisperSync` class instead of `self.WhisperSync` in the sync client initializer.