### PR TITLE
Add federation

### DIFF
--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -22,7 +22,7 @@ import logging
 import httpx
 from box import Box
 
-from Ryzenth.helper import ImagesAsync, WhatAsync, WhisperAsync
+from Ryzenth.helper import *
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] async")
@@ -35,6 +35,7 @@ class RyzenthXAsync:
         self.images = ImagesAsync(self)
         self.what = WhatAsync(self)
         self.openai_audio = WhisperAsync(self)
+        self.federation = FbanAsync(self)
         self.obj = Box
 
     async def send_downloader(

--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -20,6 +20,7 @@
 from ._images import ImagesAsync, ImagesSync
 from ._openai import WhisperAsync, WhisperSync
 from ._thinking import WhatAsync, WhatSync
+from ._federation import FbanAsync
 
 __all__ = [
   "WhisperAsync",
@@ -27,5 +28,6 @@ __all__ = [
   "ImagesAsync",
   "ImagesSync",
   "WhatAsync",
-  "WhatSync"
+  "WhatSync",
+  "FbanAsync"
 ]

--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from ._federation import FbanAsync
 from ._images import ImagesAsync, ImagesSync
 from ._openai import WhisperAsync, WhisperSync
 from ._thinking import WhatAsync, WhatSync
-from ._federation import FbanAsync
 
 __all__ = [
   "WhisperAsync",

--- a/Ryzenth/helper/_federation.py
+++ b/Ryzenth/helper/_federation.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2019-2025 (c) Randy W @xtdevs, @xtsea
+#
+# from : https://github.com/TeamKillerX
+# Channel : @RendyProjects
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+import httpx
+
+LOGS = logging.getLogger("[Ryzenth]")
+
+class FbanAsync:
+    def __init__(self, parent):
+        self.parent = parent
+
+    async def newfed(self, name: str , owner: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/newfed"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"name": name, "owner": owner},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def subfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/subfed"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"parent_uuid": parent_uuid, "child_uuid": child_uuid},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def getfed(self, uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/getfed/{uuid}"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(url, headers=self.parent.headers, timeout=30)
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def unban(self, name: str, user_id: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/unban"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"name": name, "user_id": user_id},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def ban(self, federation_uuid: str, user_id: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/ban"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"federation_uuid": federation_uuid, "user_id": user_id},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def ban_check(self, federation_uuid: str, user_id: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/ban-check"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"federation_uuid": federation_uuid, "user_id": user_id},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def fedstats(self, uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/fedstats"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    url,
+                    params={"uuid": uuid},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def unsubfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/unsubfed"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"parent_uuid": parent_uuid, "child_uuid": child_uuid},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None
+
+    async def renamefed(self, federation_uuid: str, new_name: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/renamefed"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    url,
+                    json={"federation_uuid": federation_uuid, "new_name": new_name},
+                    headers=self.parent.headers,
+                    timeout=30
+                )
+                response.raise_for_status()
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                return None


### PR DESCRIPTION
## Summary by Sourcery

Add federation functionality to the asynchronous API client by introducing a new FbanAsync helper class and integrating it into the client initialization.

New Features:
- Introduce FbanAsync class with methods to create, subscribe, retrieve, ban/unban, check bans, fetch stats, unsubscribe, and rename federations asynchronously.

Enhancements:
- Register FbanAsync in the helper module’s __all__ exports
- Attach the federation helper to the async client and adjust imports to include new helper modules