### PR TITLE
_

### DIFF
--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -22,7 +22,7 @@ import logging
 import httpx
 from box import Box
 
-from Ryzenth.helper import ImagesAsync, WhatAsync, WhisperAsync, FbanAsync
+from Ryzenth.helper import FbanAsync, ImagesAsync, WhatAsync, WhisperAsync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] async")

--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -22,7 +22,7 @@ import logging
 import httpx
 from box import Box
 
-from Ryzenth.helper import *
+from Ryzenth.helper import ImagesAsync, WhatAsync, WhisperAsync, FbanAsync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] async")

--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -1,0 +1,6 @@
+class WhatFuckError(Exception):
+    pass
+
+__all__ = [
+  "WhatFuckError"
+]

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -22,7 +22,7 @@ import logging
 import httpx
 from box import Box
 
-from Ryzenth.helper import ImagesSync, WhatSync, WhisperSync
+from Ryzenth.helper import ImagesSync, WhatSync, WhisperSync, FbanSync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] sync")
@@ -35,6 +35,7 @@ class RyzenthXSync:
         self.images = ImagesSync(self)
         self.what = WhatSync(self)
         self.openai_audio = WhisperSync(self)
+        self.federation = FbanSync(self)
         self.obj = Box
 
     def send_downloader(

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -22,7 +22,7 @@ import logging
 import httpx
 from box import Box
 
-from Ryzenth.helper import ImagesSync, WhatSync, WhisperSync, FbanSync
+from Ryzenth.helper import FbanSync, ImagesSync, WhatSync, WhisperSync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] sync")

--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from ._federation import FbanAsync
+from ._federation import FbanAsync, FbanSync
 from ._images import ImagesAsync, ImagesSync
 from ._openai import WhisperAsync, WhisperSync
 from ._thinking import WhatAsync, WhatSync
@@ -29,5 +29,6 @@ __all__ = [
   "ImagesSync",
   "WhatAsync",
   "WhatSync",
-  "FbanAsync"
+  "FbanAsync",
+  "FbanSync"
 ]

--- a/Ryzenth/helper/_federation.py
+++ b/Ryzenth/helper/_federation.py
@@ -23,6 +23,144 @@ import httpx
 
 LOGS = logging.getLogger("[Ryzenth]")
 
+class FbanSync:
+    def __init__(self, parent):
+        self.parent = parent
+
+    def newfed(self, name: str , owner: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/newfed"
+        try:
+            response = httpx.post(
+                url,
+                json={"name": name, "owner": owner},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def subfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/subfed"
+        try:
+            response = httpx.post(
+                url,
+                json={"parent_uuid": parent_uuid, "child_uuid": child_uuid},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def getfed(self, uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/getfed/{uuid}"
+        try:
+            response = httpx.get(
+                url,
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def unban(self, name: str, user_id: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/unban"
+        try:
+            response = httpx.post(
+                url,
+                json={"name": name, "user_id": user_id},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def ban(self, federation_uuid: str, user_id: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/ban"
+        try:
+            response = httpx.post(
+                url,
+                json={"federation_uuid": federation_uuid, "user_id": user_id},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def ban_check(self, federation_uuid: str, user_id: int, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/ban-check"
+        try:
+            response = httpx.post(
+                url,
+                json={"federation_uuid": federation_uuid, "user_id": user_id},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def fedstats(self, uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/fedstats"
+        try:
+            response = httpx.get(
+                url,
+                params={"uuid": uuid},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def unsubfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/unsubfed"
+        try:
+            response = httpx.post(
+                url,
+                json={"parent_uuid": parent_uuid, "child_uuid": child_uuid},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
+    def renamefed(self, federation_uuid: str, new_name: str, dot_access=False):
+        url = f"{self.parent.base_url}/v2/federation/renamefed"
+        try:
+            response = httpx.post(
+                url,
+                json={"federation_uuid": federation_uuid, "new_name": new_name},
+                headers=self.parent.headers,
+                timeout=30
+            )
+            response.raise_for_status()
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
+            return None
+
 class FbanAsync:
     def __init__(self, parent):
         self.parent = parent

--- a/Ryzenth/helper/_federation.py
+++ b/Ryzenth/helper/_federation.py
@@ -20,6 +20,7 @@
 import logging
 
 import httpx
+
 from Ryzenth._errors import WhatFuckError
 
 LOGS = logging.getLogger("[Ryzenth]")

--- a/Ryzenth/helper/_federation.py
+++ b/Ryzenth/helper/_federation.py
@@ -20,6 +20,7 @@
 import logging
 
 import httpx
+from Ryzenth._errors import WhatFuckError
 
 LOGS = logging.getLogger("[Ryzenth]")
 
@@ -39,8 +40,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from newfed {e}")
+            raise WhatFuckError("[SYNC] Error fetching from newfed") from e
 
     def subfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/subfed"
@@ -54,8 +55,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from subfed {e}")
+            raise WhatFuckError("[SYNC] Error fetching from subfed") from e
 
     def getfed(self, uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/getfed/{uuid}"
@@ -68,8 +69,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from getfed {e}")
+            raise WhatFuckError("[SYNC] Error fetching from getfed") from e
 
     def unban(self, name: str, user_id: int, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/unban"
@@ -83,8 +84,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from unban {e}")
+            raise WhatFuckError("[SYNC] Error fetching from unban") from e
 
     def ban(self, federation_uuid: str, user_id: int, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/ban"
@@ -98,8 +99,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from unban {e}")
+            raise WhatFuckError("[SYNC] Error fetching from unban") from e
 
     def ban_check(self, federation_uuid: str, user_id: int, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/ban-check"
@@ -113,8 +114,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from ban-check {e}")
+            raise WhatFuckError("[SYNC] Error fetching from ban-check") from e
 
     def fedstats(self, uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/fedstats"
@@ -128,8 +129,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from fedstats {e}")
+            raise WhatFuckError("[SYNC] Error fetching from fedstats") from e
 
     def unsubfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/unsubfed"
@@ -143,8 +144,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from unsubfed {e}")
+            raise WhatFuckError("[SYNC] Error fetching from unsubfed") from e
 
     def renamefed(self, federation_uuid: str, new_name: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/renamefed"
@@ -158,8 +159,8 @@ class FbanSync:
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            LOGS.error(f"[SYNC] Error fetching from renamefed {e}")
+            raise WhatFuckError("[SYNC] Error fetching from renamefed") from e
 
 class FbanAsync:
     def __init__(self, parent):
@@ -179,7 +180,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def subfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/subfed"
@@ -195,7 +196,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def getfed(self, uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/getfed/{uuid}"
@@ -206,7 +207,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def unban(self, name: str, user_id: int, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/unban"
@@ -222,7 +223,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def ban(self, federation_uuid: str, user_id: int, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/ban"
@@ -238,7 +239,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def ban_check(self, federation_uuid: str, user_id: int, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/ban-check"
@@ -254,7 +255,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def fedstats(self, uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/fedstats"
@@ -270,7 +271,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def unsubfed(self, parent_uuid: str, child_uuid: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/unsubfed"
@@ -286,7 +287,7 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
     async def renamefed(self, federation_uuid: str, new_name: str, dot_access=False):
         url = f"{self.parent.base_url}/v2/federation/renamefed"
@@ -302,4 +303,4 @@ class FbanAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e

--- a/Ryzenth/helper/_images.py
+++ b/Ryzenth/helper/_images.py
@@ -20,6 +20,7 @@
 import logging
 
 import httpx
+
 from Ryzenth._errors import WhatFuckError
 from Ryzenth.types import QueryParameter
 

--- a/Ryzenth/helper/_images.py
+++ b/Ryzenth/helper/_images.py
@@ -20,7 +20,7 @@
 import logging
 
 import httpx
-
+from Ryzenth._errors import WhatFuckError
 from Ryzenth.types import QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth]")
@@ -38,7 +38,7 @@ class ImagesAsync:
                 return response.content
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
 class ImagesSync:
     def __init__(self, parent):
@@ -57,4 +57,4 @@ class ImagesSync:
             return response.content
         except httpx.HTTPError as e:
             LOGS.error(f"[SYNC] Error fetching from images {e}")
-            return None
+            raise WhatFuckError("[SYNC] Error fetching from images") from e

--- a/Ryzenth/helper/_openai.py
+++ b/Ryzenth/helper/_openai.py
@@ -21,6 +21,7 @@ import logging
 
 import httpx
 
+from Ryzenth._errors import WhatFuckError
 from Ryzenth.types import OpenaiWhisper
 
 LOGS = logging.getLogger("[Ryzenth]")
@@ -38,7 +39,7 @@ class WhisperAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
 class WhisperSync:
     def __init__(self, parent):
@@ -57,4 +58,4 @@ class WhisperSync:
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
             LOGS.error(f"[SYNC] Error fetching from whisper openai {e}")
-            return None
+            raise WhatFuckError("[SYNC] Error fetching from whisper openai") from e

--- a/Ryzenth/helper/_thinking.py
+++ b/Ryzenth/helper/_thinking.py
@@ -21,6 +21,7 @@ import logging
 
 import httpx
 
+from Ryzenth._errors import WhatFuckError
 from Ryzenth.types import QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth]")
@@ -38,7 +39,7 @@ class WhatAsync:
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
-                return None
+                raise WhatFuckError("[ASYNC] Error fetching") from e
 
 class WhatSync:
     def __init__(self, parent):
@@ -57,4 +58,4 @@ class WhatSync:
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
             LOGS.error(f"[SYNC] Error fetching from deepseek {e}")
-            return None
+            raise WhatFuckError("[SYNC] Error fetching from deepseek") from e


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new federation management helper (FbanSync/FbanAsync) and standardize HTTP error handling by raising a dedicated WhatFuckError instead of returning None.

New Features:
- Implement FbanSync class with methods for managing federations (newfed, subfed, getfed, unban, ban, ban_check, fedstats, unsubfed, renamefed)
- Expose federation functionality in both sync and async clients via FbanSync and FbanAsync

Bug Fixes:
- Replace returning None on HTTP errors in helper methods with raising WhatFuckError to avoid silent failures

Enhancements:
- Introduce WhatFuckError exception and integrate it across all HTTP helper modules
- Update helper module exports to include FbanSync and FbanAsync
- Adjust sync and async client initialization to wire in the new federation helpers