### PR TITLE
_

### DIFF
--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -23,7 +23,7 @@ import httpx
 from box import Box
 
 from Ryzenth._errors import WhatFuckError
-from Ryzenth.helper import FbanAsync, ImagesAsync, WhatAsync, WhisperAsync
+from Ryzenth.helper import FbanAsync, ImagesAsync, WhatAsync, WhisperAsync, ModeratorAsync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] async")
@@ -38,6 +38,7 @@ class RyzenthXAsync:
         self.what = WhatAsync(self)
         self.openai_audio = WhisperAsync(self)
         self.federation = FbanAsync(self)
+        self.moderator = ModeratorAsync(self)
         self.obj = Box
 
     async def send_downloader(

--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -23,7 +23,7 @@ import httpx
 from box import Box
 
 from Ryzenth._errors import WhatFuckError
-from Ryzenth.helper import FbanAsync, ImagesAsync, WhatAsync, WhisperAsync, ModeratorAsync
+from Ryzenth.helper import FbanAsync, ImagesAsync, ModeratorAsync, WhatAsync, WhisperAsync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] async")

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -23,7 +23,7 @@ import httpx
 from box import Box
 
 from Ryzenth._errors import WhatFuckError
-from Ryzenth.helper import FbanSync, ImagesSync, WhatSync, WhisperSync
+from Ryzenth.helper import FbanSync, ImagesSync, WhatSync, WhisperSync, ModeratorSync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] sync")
@@ -38,6 +38,7 @@ class RyzenthXSync:
         self.what = WhatSync(self)
         self.openai_audio = WhisperSync(self)
         self.federation = FbanSync(self)
+        self.moderator = ModeratorSync(self)
         self.obj = Box
 
     def send_downloader(

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -23,7 +23,7 @@ import httpx
 from box import Box
 
 from Ryzenth._errors import WhatFuckError
-from Ryzenth.helper import FbanSync, ImagesSync, WhatSync, WhisperSync, ModeratorSync
+from Ryzenth.helper import FbanSync, ImagesSync, ModeratorSync, WhatSync, WhisperSync
 from Ryzenth.types import DownloaderBy, QueryParameter
 
 LOGS = logging.getLogger("[Ryzenth] sync")

--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -21,6 +21,7 @@ from ._federation import FbanAsync, FbanSync
 from ._images import ImagesAsync, ImagesSync
 from ._openai import WhisperAsync, WhisperSync
 from ._thinking import WhatAsync, WhatSync
+from ._moderator import ModeratorAsync ModeratorSync
 
 __all__ = [
   "WhisperAsync",
@@ -30,5 +31,7 @@ __all__ = [
   "WhatAsync",
   "WhatSync",
   "FbanAsync",
-  "FbanSync"
+  "FbanSync",
+  "ModeratorAsync",
+  "ModeratorSync",
 ]

--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -19,9 +19,9 @@
 
 from ._federation import FbanAsync, FbanSync
 from ._images import ImagesAsync, ImagesSync
+from ._moderator import ModeratorAsync, ModeratorSync
 from ._openai import WhisperAsync, WhisperSync
 from ._thinking import WhatAsync, WhatSync
-from ._moderator import ModeratorAsync ModeratorSync
 
 __all__ = [
   "WhisperAsync",

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -17,9 +17,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import logging
 import json
+import logging
 from datetime import datetime as dt
+
 import httpx
 
 from Ryzenth._errors import WhatFuckError

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -30,6 +30,55 @@ class ModeratorSync:
     def __init__(self, parent):
         self.parent = parent
 
+    async def antievalai(
+        self,
+        query: str,
+        version: str,
+        to_dict_by_loads=False,
+        dot_access=False
+    ):
+        version_params = {
+            "v1": "v1",
+            "v2": "v2"
+        }
+        _version = version_params.get(version)
+        if not _version:
+            raise ValueError("Invalid Version Name")
+
+        url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(
+                    url,
+                    params={"query": query},
+                    headers=self.parent.headers,
+                    timeout=self.parent.timeout
+                )
+                response.raise_for_status()
+                if to_dict_by_loads:
+                    try:
+                        return {
+                            "author": "TeamKillerX",
+                            f"timestamps": dt.now(),
+                            f"is_detect": json.loads(response.json()["results"])["is_detect"],
+                            "Powered by Ryzenth API"
+                        }
+                    except json.decoder.JSONDecodeError:
+                        return {
+                            "author": "TeamKillerX",
+                            f"timestamps": dt.now(),
+                            f"is_detect": False,
+                            "Powered by Ryzenth API"
+                        }
+                return self.parent.obj(response.json() or {}) if dot_access else response.json()
+            except httpx.HTTPError as e:
+                LOGS.error(f"[ASYNC] Error: {str(e)}")
+                raise WhatFuckError("[ASYNC] Error fetching") from e
+
+class ModeratorSync:
+    def __init__(self, parent):
+        self.parent = parent
+
     def antievalai(
         self,
         query: str,

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2019-2025 (c) Randy W @xtdevs, @xtsea
+#
+# from : https://github.com/TeamKillerX
+# Channel : @RendyProjects
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import json
+from datetime import datetime as dt
+import httpx
+
+from Ryzenth._errors import WhatFuckError
+
+LOGS = logging.getLogger("[Ryzenth]")
+
+class ModeratorSync:
+    def __init__(self, parent):
+        self.parent = parent
+
+    def antievalai(
+        self,
+        query: str,
+        version: str,
+        to_dict_by_loads=False,
+        dot_access=False
+    ):
+        version_params = {
+            "v1": "v1",
+            "v2": "v2"
+        }
+        _version = version_params.get(version)
+        if not _version:
+            raise ValueError("Invalid Version Name")
+
+        url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"
+        try:
+            response = httpx.get(
+                url,
+                params={"query": query},
+                headers=self.parent.headers,
+                timeout=self.parent.timeout
+            )
+            response.raise_for_status()
+            if to_dict_by_loads:
+                try:
+                    return {
+                        "author": "TeamKillerX",
+                        f"timestamps": dt.now(),
+                        f"is_detect": json.loads(response.json()["results"])["is_detect"],
+                        "Powered by Ryzenth API"
+                    }
+                except json.decoder.JSONDecodeError:
+                    return {
+                        "author": "TeamKillerX",
+                        f"timestamps": dt.now(),
+                        f"is_detect": False,
+                        "Powered by Ryzenth API"
+                    }
+            return self.parent.obj(response.json() or {}) if dot_access else response.json()
+        except httpx.HTTPError as e:
+            LOGS.error(f"[SYNC] Error fetching from antievalai {e}")
+            raise WhatFuckError("[SYNC] Error fetching from antievalai") from e

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -26,7 +26,7 @@ from Ryzenth._errors import WhatFuckError
 
 LOGS = logging.getLogger("[Ryzenth]")
 
-class ModeratorSync:
+class ModeratorAsync:
     def __init__(self, parent):
         self.parent = parent
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new content moderation endpoint by adding ModeratorAsync and ModeratorSync classes with antievalai methods, and integrate them into both async and sync client interfaces.

New Features:
- Add ModeratorAsync.antievalai and ModeratorSync.antievalai methods to support the antievalai endpoint for content moderation.

Enhancements:
- Import and expose ModeratorAsync and ModeratorSync in the helper package’s __all__.
- Instantiate self.moderator in both the async and sync main client classes.