### PR TITLE
_

### DIFF
--- a/Ryzenth/__version__.py
+++ b/Ryzenth/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.8"
+__version__ = "1.8.9"
 __author__ = "TeamKillerX"
 __title__ = "Ryzenth"
 __description__ = "Ryzenth Python API Wrapper"

--- a/Ryzenth/helper/_fonts.py
+++ b/Ryzenth/helper/_fonts.py
@@ -33,17 +33,17 @@ class FontsAsync:
 
     async def scanning(
         self,
-        query: str = None,
+        text: str = None,
         dot_access=False
     ):
         url = f"{self.parent.base_url}/v1/fonts-stylish/detected"
-        if not query:
-            raise ErrorParamsRequired("Invalid Params Query")
+        if not text:
+            raise ErrorParamsRequired("Invalid Params Text")
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
                     url,
-                    params={"query": query},
+                    params={"query": text},
                     headers=self.parent.headers,
                     timeout=self.parent.timeout
                 )
@@ -59,21 +59,21 @@ class FontsSync:
 
     def scanning(
         self,
-        query: str = None,
+        text: str = None,
         dot_access=False
     ):
         url = f"{self.parent.base_url}/v1/fonts-stylish/detected"
-        if not query:
-            raise ErrorParamsRequired("Invalid Params Query")
+        if not text:
+            raise ErrorParamsRequired("Invalid Params Text")
         try:
             response = httpx.get(
                 url,
-                params={"query": query},
+                params={"query": text},
                 headers=self.parent.headers,
                 timeout=self.parent.timeout
             )
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
-            LOGS.error(f"[SYNC] Error fetching from antievalai {e}")
-            raise WhatFuckError("[SYNC] Error fetching from antievalai") from e
+            LOGS.error(f"[SYNC] Error fetching from fonts {e}")
+            raise WhatFuckError("[SYNC] Error fetching from fonts") from e


### PR DESCRIPTION
## Summary by Sourcery

Standardize the scanning API by renaming parameters and messages to 'text' and update logs, then bump the package version.

Enhancements:
- Rename scanning method parameter from 'query' to 'text' in both async and sync fonts-stylish detectors
- Update validation error and request parameter names to use 'Text' instead of 'Query'
- Adjust error logs and exceptions to reference 'fonts' instead of 'antievalai'

Build:
- Bump version from 1.8.8 to 1.8.9