### PR TITLE
_

### DIFF
--- a/Ryzenth/helper/_fonts.py
+++ b/Ryzenth/helper/_fonts.py
@@ -33,17 +33,18 @@ class FontsAsync:
 
     async def scanning(
         self,
-        text: str = None,
+        text: str = "𝖍𝖊𝖑𝖑𝖔 𝖘𝖎𝖒𝖇𝖔𝖑",
         dot_access=False
     ):
         url = f"{self.parent.base_url}/v1/fonts-stylish/detected"
-        if not text:
-            raise ErrorParamsRequired("Invalid Params Text")
+        if not text or text == "":
+            raise ErrorParamsRequired("Invalid Params Text or Cannot Empty")
+        _params = self.parent.params if return_params_dict else {"query": text}
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
                     url,
-                    params={"query": text},
+                    params=_params,
                     headers=self.parent.headers,
                     timeout=self.parent.timeout
                 )
@@ -59,16 +60,18 @@ class FontsSync:
 
     def scanning(
         self,
-        text: str = None,
+        text: str = "𝖍𝖊𝖑𝖑𝖔 𝖘𝖎𝖒𝖇𝖔𝖑",
+        return_params_dict=False
         dot_access=False
     ):
         url = f"{self.parent.base_url}/v1/fonts-stylish/detected"
-        if not text:
-            raise ErrorParamsRequired("Invalid Params Text")
+        if not text or text == "":
+            raise ErrorParamsRequired("Invalid Params Text or Cannot Empty")
+        _params = self.parent.params if return_params_dict else {"query": text}
         try:
             response = httpx.get(
                 url,
-                params={"query": text},
+                params=_params,
                 headers=self.parent.headers,
                 timeout=self.parent.timeout
             )

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -45,7 +45,7 @@ class ModeratorAsync:
         _version = version_params.get(version)
         if not _version:
             raise ErrorParamsRequired("Invalid Version V1 or V2")
-        if query == "":
+        if not query.strip():
             raise ErrorParamsRequired("Cannot empty Query")
 
         url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -33,9 +33,9 @@ class ModeratorAsync:
 
     async def antievalai(
         self,
-        query: str,
-        version: str,
-        to_dict_by_loads=False,
+        query: str = "jasa hack",
+        version: str = "v2",
+        return_params_dict=False,
         dot_access=False
     ):
         version_params = {
@@ -45,32 +45,20 @@ class ModeratorAsync:
         _version = version_params.get(version)
         if not _version:
             raise ErrorParamsRequired("Invalid Version V1 or V2")
+        if query == "":
+            raise ErrorParamsRequired("Cannot empty Query")
 
         url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"
+        _params = self.parent.params if return_params_dict else {"query": query}
         async with httpx.AsyncClient() as client:
             try:
                 response = await client.get(
                     url,
-                    params={"query": query},
+                    params=_params,
                     headers=self.parent.headers,
                     timeout=self.parent.timeout
                 )
                 response.raise_for_status()
-                if to_dict_by_loads:
-                    try:
-                        return {
-                            "author": "TeamKillerX",
-                            f"timestamps": dt.now(),
-                            f"is_detect": json.loads(response.json()["results"])["is_detect"],
-                            "source": "Powered by Ryzenth API"
-                        }
-                    except json.decoder.JSONDecodeError:
-                        return {
-                            "author": "TeamKillerX",
-                            f"timestamps": dt.now(),
-                            f"is_detect": False,
-                            "source": "Powered by Ryzenth API"
-                        }
                 return self.parent.obj(response.json() or {}) if dot_access else response.json()
             except httpx.HTTPError as e:
                 LOGS.error(f"[ASYNC] Error: {str(e)}")
@@ -82,9 +70,9 @@ class ModeratorSync:
 
     def antievalai(
         self,
-        query: str,
-        version: str,
-        to_dict_by_loads=False,
+        query: str = "jasa hack",
+        version: str = "v2",
+        return_params_dict=False,
         dot_access=False
     ):
         version_params = {
@@ -94,31 +82,19 @@ class ModeratorSync:
         _version = version_params.get(version)
         if not _version:
             raise ErrorParamsRequired("Invalid Version V1 or V2")
+        if query == "":
+            raise ErrorParamsRequired("Cannot empty Query")
 
         url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"
+        _params = self.parent.params if return_params_dict else {"query": query}
         try:
             response = httpx.get(
                 url,
-                params={"query": query},
+                params=_params,
                 headers=self.parent.headers,
                 timeout=self.parent.timeout
             )
             response.raise_for_status()
-            if to_dict_by_loads:
-                try:
-                    return {
-                        "author": "TeamKillerX",
-                        f"timestamps": dt.now(),
-                        f"is_detect": json.loads(response.json()["results"])["is_detect"],
-                        "source": "Powered by Ryzenth API"
-                    }
-                except json.decoder.JSONDecodeError:
-                    return {
-                        "author": "TeamKillerX",
-                        f"timestamps": dt.now(),
-                        f"is_detect": False,
-                        "source": "Powered by Ryzenth API"
-                    }
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except httpx.HTTPError as e:
             LOGS.error(f"[SYNC] Error fetching from antievalai {e}")

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -23,7 +23,7 @@ from datetime import datetime as dt
 
 import httpx
 
-from Ryzenth._errors import WhatFuckError
+from Ryzenth._errors import ErrorParamsRequired, WhatFuckError
 
 LOGS = logging.getLogger("[Ryzenth]")
 
@@ -44,7 +44,7 @@ class ModeratorAsync:
         }
         _version = version_params.get(version)
         if not _version:
-            raise ValueError("Invalid Version Name")
+            raise ErrorParamsRequired("Invalid Version V1 or V2")
 
         url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"
         async with httpx.AsyncClient() as client:
@@ -93,7 +93,7 @@ class ModeratorSync:
         }
         _version = version_params.get(version)
         if not _version:
-            raise ValueError("Invalid Version Name")
+            raise ErrorParamsRequired("Invalid Version V1 or V2")
 
         url = f"{self.parent.base_url}/v1/ai/akenox/antievalai-{_version}"
         try:


### PR DESCRIPTION
## Summary by Sourcery

Simplify and unify parameter handling in `antievalai` and `scanning` helpers by introducing sensible defaults, renaming flags, enforcing input validation, consolidating HTTP params logic, and removing legacy parsing code.

Bug Fixes:
- Add validation for empty `query`, invalid `version`, and empty `text`, raising `ErrorParamsRequired` exceptions for invalid inputs.

Enhancements:
- Set default values for `query` ("jasa hack") and `version` ("v2") in both async/sync `antievalai` methods and for `text` (a sample symbol string) in `scanning` methods.
- Rename the `to_dict_by_loads` flag to `return_params_dict` to clarify its purpose across both helper methods.
- Consolidate HTTP request parameter construction to use either inherited `parent.params` or an explicit query payload based on `return_params_dict`.
- Remove the outdated JSON decoding branch in `antievalai` methods in favor of direct response processing.