### PR TITLE
update

### DIFF
--- a/Ryzenth/_client.py
+++ b/Ryzenth/_client.py
@@ -23,15 +23,6 @@ from ._asynchisded import RyzenthXAsync
 from ._synchisded import RyzenthXSync
 from .helper import Decorators
 
-
-class UrHellFrom:
-    def __init__(self, name: str, only_author=False):
-        self.decorators = Decorators()
-        self.ai = self.decorators.send_ai(name=name, only_author=only_author)
-
-    def something(self):
-        pass
-
 class ApiKeyFrom:
     def __init__(self, api_key: str = None, is_free_from_ryzenth=False):
         if api_key is Ellipsis:
@@ -47,6 +38,14 @@ class ApiKeyFrom:
         self.api_key = api_key
         self.aio = RyzenthXAsync(api_key)
         self._sync = RyzenthXSync(api_key)
+
+    def something(self):
+        pass
+
+class UrHellFrom:
+    def __init__(self, name: str, only_author=False):
+        self.decorators = Decorators(ApiKeyFrom)
+        self.ai = self.decorators.send_ai(name=name, only_author=only_author)
 
     def something(self):
         pass

--- a/Ryzenth/_client.py
+++ b/Ryzenth/_client.py
@@ -23,6 +23,7 @@ from ._asynchisded import RyzenthXAsync
 from ._synchisded import RyzenthXSync
 from .helper import Decorators
 
+
 class ApiKeyFrom:
     def __init__(self, api_key: str = None, is_free_from_ryzenth=False):
         if api_key is Ellipsis:

--- a/Ryzenth/helper/_decorators.py
+++ b/Ryzenth/helper/_decorators.py
@@ -19,13 +19,11 @@
 
 from functools import wraps
 
-from .._client import ApiKeyFrom
 from ..types import QueryParameter
 
-
 class Decorators:
-    def __init__(self):
-        self._clients_ai = ApiKeyFrom(..., is_free_from_ryzenth=True)
+    def __init__(self, class_func):
+        self._clients_ai = class_func(..., is_free_from_ryzenth=True)
 
     def send_ai(self, name: str, only_author=False):
         def decorator(func):

--- a/Ryzenth/helper/_decorators.py
+++ b/Ryzenth/helper/_decorators.py
@@ -21,6 +21,7 @@ from functools import wraps
 
 from ..types import QueryParameter
 
+
 class Decorators:
     def __init__(self, class_func):
         self._clients_ai = class_func(..., is_free_from_ryzenth=True)


### PR DESCRIPTION
## Summary by Sourcery

Enable flexible injection of the API key client into Decorators and adjust UrHellFrom accordingly

Enhancements:
- Decouple the Decorators class from a hardcoded ApiKeyFrom by injecting the client class via its constructor
- Update UrHellFrom to instantiate Decorators with ApiKeyFrom and reinsert it below ApiKeyFrom
- Remove redundant import and default client initialization in the helper module