### PR TITLE
_

### DIFF
--- a/Ryzenth/_client.py
+++ b/Ryzenth/_client.py
@@ -174,7 +174,7 @@ class RyzenthApiClient:
             timeout=timeout,
             allow_redirects=allow_redirects
         )
-        SyncStatusError(resp, use_httpx=False)
+        SyncStatusError(resp, status_httpx=False)
         resp.raise_for_status()
         if use_type == ResponseType.IMAGE:
             return resp.content

--- a/Ryzenth/helper/_federation.py
+++ b/Ryzenth/helper/_federation.py
@@ -45,7 +45,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -69,7 +69,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -91,7 +91,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -115,7 +115,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -139,7 +139,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -163,7 +163,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -186,7 +186,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -210,7 +210,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -234,7 +234,7 @@ class FbanSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -262,7 +262,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -284,7 +284,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -304,7 +304,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -326,7 +326,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -348,7 +348,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -370,7 +370,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -391,7 +391,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -413,7 +413,7 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -435,6 +435,6 @@ class FbanAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()

--- a/Ryzenth/helper/_fonts.py
+++ b/Ryzenth/helper/_fonts.py
@@ -50,7 +50,7 @@ class FontsAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -77,7 +77,7 @@ class FontsSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:

--- a/Ryzenth/helper/_images.py
+++ b/Ryzenth/helper/_images.py
@@ -49,7 +49,7 @@ class ImagesAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return response.content
 
@@ -75,7 +75,7 @@ class ImagesSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return response.content
         except self.parent.httpx.HTTPError as e:

--- a/Ryzenth/helper/_moderator.py
+++ b/Ryzenth/helper/_moderator.py
@@ -56,7 +56,7 @@ class ModeratorAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -86,7 +86,7 @@ class ModeratorAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -119,7 +119,7 @@ class ModeratorSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:
@@ -150,7 +150,7 @@ class ModeratorSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:

--- a/Ryzenth/helper/_openai.py
+++ b/Ryzenth/helper/_openai.py
@@ -47,7 +47,7 @@ class WhisperAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -70,7 +70,7 @@ class WhisperSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:

--- a/Ryzenth/helper/_ryzenth.py
+++ b/Ryzenth/helper/_ryzenth.py
@@ -49,7 +49,7 @@ class HumanizeAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             if pickle_json:
                 result = response.json()["results"]
@@ -76,7 +76,7 @@ class HumanizeSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             if pickle_json:
                 result = response.json()["results"]

--- a/Ryzenth/helper/_thinking.py
+++ b/Ryzenth/helper/_thinking.py
@@ -47,7 +47,7 @@ class WhatAsync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            await AsyncStatusError(response, use_httpx=True)
+            await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
 
@@ -70,7 +70,7 @@ class WhatSync:
                 headers=self.parent.headers,
                 timeout=timeout
             )
-            SyncStatusError(response, use_httpx=True)
+            SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
             return self.parent.obj(response.json() or {}) if dot_access else response.json()
         except self.parent.httpx.HTTPError as e:

--- a/Ryzenth/tests/test_deepseek.py
+++ b/Ryzenth/tests/test_deepseek.py
@@ -6,7 +6,7 @@ from ..types import QueryParameter
 def test_deepseek():
     ryz = ApiKeyFrom(..., True)
     result = ryz._sync.what.think(
-        QueryParameter(
+        params=QueryParameter(
             query="ok test"
         )
     )


### PR DESCRIPTION
## Summary by Sourcery

Standardize the status error flag across synchronous and asynchronous helper functions by renaming the `use_httpx` parameter to `status_httpx`, update the core client to match this change, and adjust the test to use the `params` keyword for `QueryParameter`.

Enhancements:
- Replace `use_httpx` with `status_httpx` in all SyncStatusError and AsyncStatusError calls across helper modules.
- Update `sync_get` in the client to use the `status_httpx` flag instead of `use_httpx`.

Tests:
- Adjust `test_deepseek.py` to pass `QueryParameter` via the `params` keyword.