### PR TITLE
_

### DIFF
--- a/Ryzenth/__version__.py
+++ b/Ryzenth/__version__.py
@@ -4,7 +4,7 @@ import platform
 def get_user_agent() -> str:
     return f"Ryzenth/Python-{platform.python_version()}"
 
-__version__ = "2.0.9"
+__version__ = "2.1.0"
 __author__ = "TeamKillerX"
 __title__ = "Ryzenth"
 __description__ = "Ryzenth is a flexible Multi-API SDK with built-in support for API key management and database integration."

--- a/Ryzenth/tests/test_deepseek.py
+++ b/Ryzenth/tests/test_deepseek.py
@@ -8,7 +8,7 @@ def test_deepseek():
     result = ryz._sync.what.think(
         params=QueryParameter(
             query="ok test"
-        )
+        ),
         timeout=10
     )
     assert result is not None

--- a/Ryzenth/tests/test_deepseek.py
+++ b/Ryzenth/tests/test_deepseek.py
@@ -9,5 +9,6 @@ def test_deepseek():
         params=QueryParameter(
             query="ok test"
         )
+        timeout=10
     )
     assert result is not None


### PR DESCRIPTION
## Summary by Sourcery

Add a timeout argument to the deepseek test call and bump package version to 2.1.0

Tests:
- Include timeout=10 in the ryz._sync.what.think test invocation

Chores:
- Update project version from 2.0.9 to 2.1.0