### PR TITLE
_

### DIFF
--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -110,6 +110,7 @@ class RyzenthXAsync:
 
     async def _client_message_get(
         self,
+        *,
         client,
         params,
         timeout,
@@ -124,6 +125,7 @@ class RyzenthXAsync:
 
     async def _client_downloader_get(
         self,
+        *,
         client,
         params,
         timeout,

--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -19,7 +19,7 @@
 
 import logging
 import platform
-from typing import Union
+import typing as t
 
 import aiohttp
 import httpx
@@ -79,16 +79,16 @@ class RyzenthXAsync:
         self,
         *,
         switch_name: str,
-        params: Union[
+        params: t.Union[
         DownloaderBy,
         QueryParameter,
         Username,
         RequestXnxx
         ] = None,
-        params_only=True,
-        on_render=False,
-        dot_access=False
-    ):
+        params_only: bool = True,
+        on_render: bool = False,
+        dot_access: bool = False
+    ) -> t.Union[dict, Box]:
 
         dl_dict = BASE_DICT_RENDER if on_render else BASE_DICT_OFFICIAL
         model_name = dl_dict.get(switch_name)
@@ -127,10 +127,10 @@ class RyzenthXAsync:
         self,
         *,
         model: str,
-        params: QueryParameter = None,
-        use_full_model_list=False,
-        dot_access=False
-    ):
+        params: QueryParameter,
+        use_full_model_list: bool = False,
+        dot_access: bool = False
+    ) -> t.Union[dict, Box]:
 
         model_dict = BASE_DICT_AI_RYZENTH if use_full_model_list else {"hybrid": "AkenoX-1.9-Hybrid"}
         model_param = model_dict.get(model)

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -125,7 +125,7 @@ class RyzenthXSync:
         self,
         *,
         model: str,
-        params: QueryParameter = None,
+        params: QueryParameter,
         timeout: t.Union[int, float] = 5,
         use_full_model_list: bool = False,
         dot_access: bool = False

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -19,7 +19,7 @@
 
 import logging
 import platform
-from typing import Union
+import typing as t
 
 import httpx
 import requests
@@ -77,16 +77,17 @@ class RyzenthXSync:
         self,
         *,
         switch_name: str,
-        params: Union[
+        params: t.Union[
         DownloaderBy,
         QueryParameter,
         Username,
         RequestXnxx
         ] = None,
-        params_only=True,
-        on_render=False,
-        dot_access=False
-    ):
+        timeout: t.Union[int, float] = 5,
+        params_only: bool = True,
+        on_render: bool = False,
+        dot_access: bool = False
+    ) -> t.Union[dict, Box]:
         dl_dict = BASE_DICT_RENDER if on_render else BASE_DICT_OFFICIAL
         model_name = dl_dict.get(switch_name)
         if not model_name:
@@ -96,7 +97,7 @@ class RyzenthXSync:
                 f"{self.base_url}/v1/dl/{model_name}",
                 params=params.model_dump() if params_only else None,
                 headers=self.headers,
-                timeout=self.timeout
+                timeout=timeout
             )
             SyncStatusError(response, status_httpx=True)
             response.raise_for_status()
@@ -124,9 +125,10 @@ class RyzenthXSync:
         *,
         model: str,
         params: QueryParameter = None,
-        use_full_model_list=False,
-        dot_access=False
-    ):
+        timeout: t.Union[int, float] = 5,
+        use_full_model_list: bool = False,
+        dot_access: bool = False
+    ) -> t.Union[dict, Box]:
         model_dict = BASE_DICT_AI_RYZENTH if use_full_model_list else {"hybrid": "AkenoX-1.9-Hybrid"}
         model_param = model_dict.get(model)
         if not model_param:
@@ -137,7 +139,7 @@ class RyzenthXSync:
                 f"{self.base_url}/v1/ai/akenox/{model_param}",
                 params=params.model_dump(),
                 headers=self.headers,
-                timeout=self.timeout
+                timeout=timeout
             )
             SyncStatusError(response, status_httpx=True)
             response.raise_for_status()

--- a/Ryzenth/_synchisded.py
+++ b/Ryzenth/_synchisded.py
@@ -111,7 +111,8 @@ class RyzenthXSync:
                 response_ = requests.get(
                     f"{self.base_url}/v1/dl/{model_name}",
                     params=params.model_dump() if params_only else None,
-                    headers=self.headers
+                    headers=self.headers,
+                    timeout=timeout
                 )
                 response_.raise_for_status()
                 SyncStatusError(response_, status_httpx=True)
@@ -153,7 +154,8 @@ class RyzenthXSync:
                 response_ = requests.get(
                     f"{self.base_url}/v1/ai/akenox/{model_param}",
                     params=params.model_dump(),
-                    headers=self.headers
+                    headers=self.headers,
+                    timeout=timeout
                 )
                 response_.raise_for_status()
                 SyncStatusError(response_, status_httpx=True)

--- a/Ryzenth/helper/_federation.py
+++ b/Ryzenth/helper/_federation.py
@@ -32,7 +32,8 @@ class FbanSync:
     @Benchmark.sync(level=logging.DEBUG)
     def newfed(
         self,
-        name: str ,
+        *,
+        name: str,
         owner: int,
         timeout: t.Union[int, float] = 5,
         dot_access: bool = False
@@ -249,7 +250,8 @@ class FbanAsync:
     @AutoRetry(max_retries=3, delay=1.5)
     async def newfed(
         self,
-        name: str ,
+        *,
+        name: str,
         owner: int,
         timeout: t.Union[int, float] = 5,
         dot_access: bool = False


### PR DESCRIPTION
## Summary by Sourcery

Enhance HTTP methods with configurable request timeouts, reinforce type annotations throughout send_downloader and send_message (sync and async), and enforce keyword-only parameters in federation helper methods.

Enhancements:
- Add a timeout argument to send_downloader, send_message, and related HTTP client methods to allow custom request timeouts
- Annotate return types of send_downloader and send_message to Union[dict, Box]
- Change the internal HTTP calls to use the passed timeout parameter instead of a fixed class attribute
- Use keyword-only arguments for the name parameter in helper/_federation newfed methods for consistent API signatures
- Update type annotations to use t.Union and explicit bool typing for flag parameters