### PR TITLE
_

### DIFF
--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -160,7 +160,7 @@ class RyzenthXAsync:
                 client=client,
                 params=params,
                 timeout=timeout,
-                model_param
+                model_param=model_param
             )
             await AsyncStatusError(response, status_httpx=True)
             response.raise_for_status()

--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -26,6 +26,7 @@ import httpx
 from box import Box
 
 from .__version__ import get_user_agent
+from ._benchmark import Benchmark
 from ._errors import (
     AsyncStatusError,
     InvalidModelError,
@@ -33,7 +34,6 @@ from ._errors import (
     WhatFuckError,
 )
 from ._shared import BASE_DICT_AI_RYZENTH, BASE_DICT_OFFICIAL, BASE_DICT_RENDER
-from ._benchmark import Benchmark
 from .helper import (
     AutoRetry,
     FbanAsync,

--- a/Ryzenth/_asynchisded.py
+++ b/Ryzenth/_asynchisded.py
@@ -33,6 +33,7 @@ from ._errors import (
     WhatFuckError,
 )
 from ._shared import BASE_DICT_AI_RYZENTH, BASE_DICT_OFFICIAL, BASE_DICT_RENDER
+from ._benchmark import Benchmark
 from .helper import (
     AutoRetry,
     FbanAsync,
@@ -74,6 +75,7 @@ class RyzenthXAsync:
             handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
             self.logger.addHandler(handler)
 
+    @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
     async def send_downloader(
         self,
@@ -139,6 +141,7 @@ class RyzenthXAsync:
             timeout=timeout
         )
 
+    @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
     async def send_message(
         self,


### PR DESCRIPTION
## Summary by Sourcery

Decorate send_downloader and send_message with performance benchmarking at DEBUG level and align send_message’s parameter passing with explicit keyword arguments.

Enhancements:
- Add @Benchmark.performance(level=logging.DEBUG) decorator to send_downloader and send_message methods
- Pass model_param as a keyword argument in send_message instead of positional