### PR TITLE
_

### DIFF
--- a/Ryzenth/tool/yogik.py
+++ b/Ryzenth/tool/yogik.py
@@ -42,7 +42,7 @@ class YogikClient:
     #TODO: HERE ADDED
     @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
-    """All In One Downloader""""
+    """All In One Downloader"""
     async def aio(self, *, url: str, **kwargs):
         if not url or not url.strip():
             raise ParamsRequiredError("The 'url' parameter must not be empty or whitespace.")

--- a/Ryzenth/tool/yogik.py
+++ b/Ryzenth/tool/yogik.py
@@ -42,7 +42,6 @@ class YogikClient:
     #TODO: HERE ADDED
     @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
-    """All In One Downloader"""
     async def aio(self, *, url: str, **kwargs):
         if not url or not url.strip():
             raise ParamsRequiredError("The 'url' parameter must not be empty or whitespace.")
@@ -56,7 +55,6 @@ class YogikClient:
 
     @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
-    """All In One Downloader V2"""
     async def aiov2(self, *, url: str, **kwargs):
         if not url or not url.strip():
             raise ParamsRequiredError("The 'url' parameter must not be empty or whitespace.")


### PR DESCRIPTION
## Summary by Sourcery

Remove redundant triple-quoted strings from the aio and aiov2 methods in yogik.py

Enhancements:
- Remove stray docstring from aio method
- Remove stray docstring from aiov2 method