### PR TITLE
_

### DIFF
--- a/Ryzenth/__version__.py
+++ b/Ryzenth/__version__.py
@@ -4,7 +4,7 @@ import platform
 def get_user_agent() -> str:
     return f"Ryzenth/Python-{platform.python_version()}"
 
-__version__ = "2.1.4"
+__version__ = "2.1.5"
 __author__ = "TeamKillerX"
 __title__ = "Ryzenth"
 __description__ = "Ryzenth is a flexible Multi-API SDK with built-in support for API key management and database integration."

--- a/Ryzenth/tool/ytdlpyton.py
+++ b/Ryzenth/tool/ytdlpyton.py
@@ -83,7 +83,7 @@ class YtdlPythonClient:
     @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
     async def search(self, *, query: str, **kwargs):
-        if not query or not query.strip()
+        if not query or not query.strip():
             raise ParamsRequiredError("The 'query' parameter must not be empty or whitespace.")
         clients = await self.start()
         return await clients.get(


### PR DESCRIPTION
## Summary by Sourcery

Bump package version to 2.1.5 and fix query validation syntax in the search method

Bug Fixes:
- Add missing colon in the search method's `if not query` validation to prevent syntax errors

Chores:
- Update __version__ to 2.1.5