### PR TITLE
_

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ print(response)
 
 ## Environment Variable Support
 - Available API key v2 via [`@RyzenthKeyBot`](https://t.me/RyzenthKeyBot)
-- Tools Required API key: [`#HERE`](https://github.com/TeamKillerX/Ryzenth/dev/README.md#how-to-get-api-key)
+- Tools Required API key: [`#HERE`](https://github.com/TeamKillerX/Ryzenth?tab=readme-ov-file#how-to-get-api-key)
 
 You can skip passing the API key (**Only Ryzenth not tools**) directly by setting it via environment:
 

--- a/Ryzenth/_client.py
+++ b/Ryzenth/_client.py
@@ -322,7 +322,7 @@ class RyzenthApiClient:
                 headers=headers,
                 timeout=timeout
             ) as resp:
-                await AsyncStatusError(resp, status_httpx=True)
+                await AsyncStatusError(resp, status_httpx=False)
                 resp.raise_for_status()
                 if use_type == ResponseType.IMAGE:
                     data = await resp.read()


### PR DESCRIPTION
## Summary by Sourcery

Update README link for API key instructions and adjust HTTP status error handling flag.

Bug Fixes:
- Change AsyncStatusError invocation to disable httpx-specific status checking.

Documentation:
- Correct the API key retrieval documentation link in README to point to the proper section.