### PR TITLE
_

### DIFF
--- a/Ryzenth/__version__.py
+++ b/Ryzenth/__version__.py
@@ -4,7 +4,7 @@ import platform
 def get_user_agent() -> str:
     return f"Ryzenth/Python-{platform.python_version()}"
 
-__version__ = "2.1.7"
+__version__ = "2.1.8"
 __author__ = "TeamKillerX"
 __title__ = "Ryzenth"
 __description__ = "Ryzenth is a flexible Multi-API SDK with built-in support for API key management and database integration."

--- a/Ryzenth/_client.py
+++ b/Ryzenth/_client.py
@@ -184,7 +184,7 @@ class RyzenthApiClient:
             timeout=timeout,
             allow_redirects=allow_redirects
         )
-        SyncStatusError(resp, status_httpx=False)
+        SyncStatusError(resp, status_httpx=True)
         resp.raise_for_status()
         if use_type == ResponseType.IMAGE:
             return resp.content
@@ -273,7 +273,7 @@ class RyzenthApiClient:
             timeout=timeout,
             allow_redirects=allow_redirects
         )
-        SyncStatusError(resp, status_httpx=False)
+        SyncStatusError(resp, status_httpx=True)
         resp.raise_for_status()
         if use_type == ResponseType.IMAGE:
             return resp.content


### PR DESCRIPTION
## Summary by Sourcery

Fix the HTTPX status flag in synchronous request error handling and bump the package version.

Bug Fixes:
- Enable status_httpx=True in SyncStatusError for sync_get and sync_post to ensure proper HTTPX error mapping.

Chores:
- Bump version from 2.1.7 to 2.1.8.