### PR TITLE
Changed updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install ryzenth[fast]
 ### New chaining Support
 - Use syntax `\`
 - Allow using `&` for parameters
-- You need login in [`ryzenths.dpdns.org`](https://ryzenths.dpdns.org)
+- You need to log in to [`ryzenths.dpdns.org`](https://ryzenths.dpdns.org)
 ```py
 from Ryzenth import RyzenthAuthClient
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ It supports both **synchronous and asynchronous** workflows out of the box, maki
 
 With native integration for `httpx`, `aiohttp`, advanced logging (including optional Telegram alerts), and support for database storage like MongoDB, Ryzenth is designed for developers who need a lightweight, scalable, and customizable API client.
 
-> Note: Ryzenth API V1 (**javascript**) is still alive and supported, but Ryzenth is the next generation.
-
 ## Features
 
 - Full support for both `sync` and `async` clients
@@ -41,8 +39,27 @@ pip install ryzenth[fast]
 
 ## Getting Started
 
-### Async Example
+### New chaining Support
+- Use syntax `\`
+- Allow using `&` for parameters
+- You need login in [`ryzenths.dpdns.org`](https://ryzenths.dpdns.org)
+```py
+from Ryzenth import RyzenthAuthClient
 
+response = await RyzenthAuthClient()\
+.with_credentials("me@gmail.com", "sk-ryzenth-*")\
+.use_tool("instatiktok")\
+.set_paramater("&url={url}&platform=facebook")\
+.retry(2)\
+.cache(True)\
+.timeout(10)\
+.execute()
+
+print(response)
+```
+
+### Async Example (Deprecated)
+- Old endpoint has been deprecated and will no longer be supported.
 ```python
 from Ryzenth import ApiKeyFrom
 from Ryzenth.types import QueryParameter
@@ -57,8 +74,8 @@ await ryz.aio.send_message(
 )
 ```
 
-### Sync Example
-
+### Sync Example (Deprecated)
+- Old endpoint has been deprecated and will no longer be supported.
 ```python
 from Ryzenth import ApiKeyFrom
 from Ryzenth.types import QueryParameter
@@ -96,18 +113,6 @@ response = await g.chat_completions(
 )
 print(response)
 ```
--> [`Tools`](https://github.com/TeamKillerX/Ryzenth/tree/beta/Ryzenth/tool) - Tools Developers
-
-## Environment Variable Support
-- Available API key v2 via [`@RyzenthKeyBot`](https://t.me/RyzenthKeyBot)
-- Tools Required API key: [`#HERE`](https://github.com/TeamKillerX/Ryzenth?tab=readme-ov-file#how-to-get-api-key)
-
-You can skip passing the API key (**Only Ryzenth not tools**) directly by setting it via environment:
-
-```bash
-export RYZENTH_API_KEY=your-api-key
-```
-
 ## Tool Developer
 ~ Artificial Intelligence
 - [`OpenAI`](https://platform.openai.com/docs) - OpenAI Docs
@@ -118,7 +123,7 @@ export RYZENTH_API_KEY=your-api-key
 - [`Grok AI key`](https://docs.x.ai/docs) - Grok AI Docs
 
 ## How to get api key?
-- [`Ryzenth API key`](https://t.me/RyzenthKeyBot) - Telegram bot
+- [`Ryzenth API key`](https://ryzenths.dpdns.org) - Website official
 - [`Openai API key`](https://platform.openai.com/api-keys) - Website official
 - [`Cohere API key`](https://dashboard.cohere.com/api-keys) - Website official
 - [`Alibaba API key`](https://bailian.console.alibabacloud.com/?tab=playground#/api-key) - Website official

--- a/Ryzenth/__init__.py
+++ b/Ryzenth/__init__.py
@@ -21,10 +21,12 @@ from . import *
 from .__version__ import __version__
 from ._base_client import ApiKeyFrom, FromConvertDot, UrHellFrom
 from ._client import RyzenthApiClient
+from ._new_client import RyzenthAuthClient
 
 __all__ = [
   "ApiKeyFrom",
   "RyzenthApiClient",
+  "RyzenthAuthClient",
   "UrHellFrom",
   "FromConvertDot"
 ]

--- a/Ryzenth/_new_client.py
+++ b/Ryzenth/_new_client.py
@@ -48,8 +48,8 @@ class RyzenthAuthClient:
         self._tool = tool
         return self
 
-    def set_paramater(self, set_paramater: str):
-        self._set_paramater = set_paramater
+    def set_parameter(self, set_parameter: str):
+        self._set_paramater = set_parameter
         return self
 
     def retry(self, times: int = 3):

--- a/Ryzenth/_new_client.py
+++ b/Ryzenth/_new_client.py
@@ -17,13 +17,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import logging
 import asyncio
+import logging
 import typing as t
+
 from ._benchmark import Benchmark
 from ._client import RyzenthApiClient
 from .enums import ResponseType
 from .helper import AutoRetry
+
 
 class RyzenthAuthClient:
     def __init__(self):

--- a/Ryzenth/_new_client.py
+++ b/Ryzenth/_new_client.py
@@ -80,7 +80,7 @@ class RyzenthAuthClient:
 
         client = await self._ensure_client()
 
-        path = f"/api/tools/{self._tool}?account_email={self._email}&tools-api-key={self._key}{self._set_paramater}"
+        path = f"/api/tools/{self._tool}?account_email={self._email}&tools-api-key={self._key}{self._set_parameter}"
         if self._use_cache and path in self._cache:
             return self._cache[path]
 

--- a/Ryzenth/_new_client.py
+++ b/Ryzenth/_new_client.py
@@ -29,7 +29,7 @@ class RyzenthAuthClient:
     def __init__(self):
         self._email: t.Optional[str] = None
         self._key: t.Optional[str] = None
-        self._set_paramater: t.Optional[str] = None
+        self._set_parameter: t.Optional[str] = None
         self._tool: t.Optional[str] = None
         self._retries: int = 0
         self._use_cache: bool = False

--- a/Ryzenth/_new_client.py
+++ b/Ryzenth/_new_client.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2019-2025 (c) Randy W @xtdevs, @xtsea
+#
+# from : https://github.com/TeamKillerX
+# Channel : @RendyProjects
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import asyncio
+import typing as t
+from ._benchmark import Benchmark
+from ._client import RyzenthApiClient
+from .enums import ResponseType
+from .helper import AutoRetry
+
+class RyzenthAuthClient:
+    def __init__(self):
+        self._email: t.Optional[str] = None
+        self._key: t.Optional[str] = None
+        self._set_paramater: t.Optional[str] = None
+        self._tool: t.Optional[str] = None
+        self._retries: int = 0
+        self._use_cache: bool = False
+        self._timeout: int = 30
+        self._client = None
+        self._cache = {}
+
+    def with_credentials(self, email: str, key: str):
+        self._email = email
+        self._key = key
+        return self
+
+    def use_tool(self, tool: str):
+        self._tool = tool
+        return self
+
+    def set_paramater(self, set_paramater: str):
+        self._set_paramater = set_paramater
+        return self
+
+    def retry(self, times: int = 3):
+        self._retries = times
+        return self
+
+    def cache(self, enabled: bool = True):
+        self._use_cache = enabled
+        return self
+
+    def timeout(self, seconds: int):
+        self._timeout = seconds
+        return self
+
+    async def _ensure_client(self):
+        if not self._client:
+            self._client = await RyzenthApiClient(
+                tools_name=["ryzenth-v2"],
+                api_key={"ryzenth-v2": [{}]},
+                rate_limit=100,
+                use_default_headers=True,
+            )
+        return self._client
+
+    async def execute(self):
+        if not all([self._email, self._key, self._tool]):
+            raise ValueError("Email, API key, and tool must be set")
+
+        client = await self._ensure_client()
+
+        path = f"/api/tools/{self._tool}?account_email={self._email}&tools-api-key={self._key}{self._set_paramater}"
+        if self._use_cache and path in self._cache:
+            return self._cache[path]
+
+        for attempt in range(1, self._retries + 2):
+            try:
+                response = await client.get(
+                    tool="ryzenth-v2",
+                    path=path,
+                    timeout=self._timeout
+                )
+                if self._use_cache:
+                    self._cache[path] = response
+                return response
+            except Exception as e:
+                if attempt > self._retries:
+                    raise e
+                await asyncio.sleep(1 * attempt)

--- a/Ryzenth/_shared.py
+++ b/Ryzenth/_shared.py
@@ -3,7 +3,8 @@ UNKNOWN_TEST = "YWtlbm9fVUtRRVFNdDk5MWtoMkVoaDdKcUpZS2FweDhDQ3llQw=="
 
 TOOL_DOMAIN_MAP = {
     "itzpire": "https://itzpire.com",
-    "ryzenth": "https://randydev-ryu-js.hf.space",
+    "ryzenth": "https://ryzenth-api.onrender.com",
+    "ryzenth-v2": "https://api.ryzenths.dpdns.org",
     "onrender": "https://x-api-js.onrender.com",
     "deepseek": "https://api.deepseek.com",
     "cloudflare": "https://api.cloudflare.com",

--- a/Ryzenth/tests/test_deepseek.py
+++ b/Ryzenth/tests/test_deepseek.py
@@ -1,3 +1,5 @@
+"""API is disabled move to domain new
+
 from Ryzenth import ApiKeyFrom
 
 from ..types import QueryParameter
@@ -12,3 +14,4 @@ def test_deepseek():
         timeout=10
     )
     assert result is not None
+"""

--- a/Ryzenth/tests/test_moderator.py
+++ b/Ryzenth/tests/test_moderator.py
@@ -1,3 +1,5 @@
+"""API is disabled move to domain new
+
 from Ryzenth import ApiKeyFrom
 
 
@@ -10,3 +12,4 @@ def test_moderator():
             dot_access=False
     )
     assert result is not None
+"""

--- a/Ryzenth/tests/test_send.py
+++ b/Ryzenth/tests/test_send.py
@@ -1,3 +1,5 @@
+"""API is disabled move to domain new
+
 from Ryzenth import ApiKeyFrom
 from Ryzenth.types import QueryParameter
 
@@ -10,3 +12,4 @@ def test_send_message_melayu():
         use_full_model_list=True
     )
     assert result is not None
+"""

--- a/Ryzenth/tests/test_send_downloader.py
+++ b/Ryzenth/tests/test_send_downloader.py
@@ -1,3 +1,5 @@
+"""API is disabled move to domain new
+
 from Ryzenth._synchisded import RyzenthXSync
 from Ryzenth.types import QueryParameter, RequestXnxx, Username
 
@@ -35,3 +37,4 @@ def test_xnxxdl():
         on_render=True
     )
     assert result is not None
+"""


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new authenticated chaining client (RyzenthAuthClient) for the v2 API, update endpoint configurations and documentation to reflect the new approach, and disable legacy tests.

New Features:
- Introduce RyzenthAuthClient for authenticated method-chaining with credentials, parameters, retry, cache, and timeout support

Enhancements:
- Add "ryzenth-v2" endpoint and update the default "ryzenth" URL in TOOL_DOMAIN_MAP
- Export RyzenthAuthClient in the package __init__.py
- Update README to showcase the new chaining client, deprecate old sync/async examples, and replace the API key retrieval link

Documentation:
- Remove environment variable support section from README

Tests:
- Disable legacy test modules by wrapping them in docstrings