### PR TITLE
Beta

### DIFF
--- a/Ryzenth/_export_class.py
+++ b/Ryzenth/_export_class.py
@@ -42,9 +42,9 @@ class GeneratedImageOrVideo:
             )
             status = result["output"]["task_status"]
             if status == "SUCCEEDED":
-                return result["output"]["results"][0]["url"] if return_img_url else result["output"]["video_url"]
+                return self._client.dict_convert_to_dot(result["output"])
             elif status == "FAILED":
-                raise WhatFuckError("Qwen Failed to generate image")
+                raise WhatFuckError("Qwen Failed to generate image or video")
             await asyncio.sleep(poll_interval)
             retries += 1
         raise WhatFuckError(f"Task polling exceeded maximum retries ({max_retries})")
@@ -77,4 +77,4 @@ class GeneratedImageOrVideo:
         return io.BytesIO(self._content)
 
     def __repr__(self):
-        return f"<GeneratedImage path={self._file_path}>"
+        return f"<GeneratedImageOrVideo path={self._file_path}>"

--- a/Ryzenth/new_helper/_qwen_images.py
+++ b/Ryzenth/new_helper/_qwen_images.py
@@ -64,12 +64,15 @@ class ImagesQwenAsync:
         prompt: str,
         *,
         negative_prompt: str = "",
-        seed: Union[int, float, None] = 0,
+        seed: Optional[int] = 0,
         size: str = "1024*1024",
         prompt_extend: bool = True,
     ) -> GeneratedImageOrVideo:
         if not prompt or not prompt.strip():
             raise WhatFuckError("Prompt cannot be empty")
+
+        if seed is not None and not isinstance(seed, int):
+            raise WhatFuckError(f"Seed must be an integer or None, got {type(seed).__name__}")
 
         client = self._get_client()
         try:

--- a/Ryzenth/new_helper/_qwen_videos.py
+++ b/Ryzenth/new_helper/_qwen_videos.py
@@ -64,12 +64,15 @@ class VideosQwenAsync:
         prompt: str,
         *,
         negative_prompt: str = "",
-        seed: Union[int, str, None] = 0,
-        size: str = "624×624",
+        seed: Optional [int] = 0,
+        size: str = "624*624",
         prompt_extend: bool = True,
     ) -> GeneratedImageOrVideo:
         if not prompt or not prompt.strip():
             raise WhatFuckError("Prompt cannot be empty")
+
+        if seed is not None and not isinstance(seed, int):
+            raise WhatFuckError(f"Seed must be an integer or None, got {type(seed).__name__}")
 
         client = self._get_client()
         try:


### PR DESCRIPTION
## Summary by Sourcery

Tighten input validation for Qwen image and video generation, standardize size formatting, and harmonize export responses and error messages

Enhancements:
- Enforce integer-only seed values (or None) and reject other types in both image and video create functions
- Standardize video size string to use '*' delimiter instead of '×'
- Return the full output object (converted to dot-accessible form) from create_task_and_wait instead of just a URL
- Update failure error text to include both image and video generation errors
- Rename representation and related types from GeneratedImage to GeneratedImageOrVideo for consistency