### PR TITLE
_

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ const gh = req.headers['X-Github-Source'];
 
 console.log(gh) // check valid whitelist TeamKillerX/Ryzenth
 
-const EXTRA_ALLOWED_UA = ["Ryzenth/Python"];
+const ALLOWED_UA_REGEX = /^Ryzenth\/(Python|TS|Rust)-\d+\.\d+/;
+
+const EXTRA_ALLOWED_UA = [
+  "Mozilla/5.0 ......."
+];
 
 const isAllowed = ALLOWED_UA_REGEX.test(ua || "") ||
                     EXTRA_ALLOWED_UA.some(allowed => ua?.startsWith(allowed));


### PR DESCRIPTION
## Summary by Sourcery

Enhance the allowed user-agent filtering example in the README

Documentation:
- Use a regex to match Ryzenth user agents with version numbers
- Expand EXTRA_ALLOWED_UA with additional example user-agent strings