### PR TITLE
_

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ The library automatically adds these headers when `use_default_headers=True`:
 - `Content-Type: application/json`
 
 ### Javascript Your own API
-
-- Added headers this
 ```js
-const ua = req.headers['user-agent'];
+const ua = req.headers['User-Agent'];
 const gh = req.headers['X-Github-Source'];
 const ghVersion = req.headers['X-Ryzenth-Version'];
 


### PR DESCRIPTION
## Summary by Sourcery

Fix header casing and clean up formatting in README's JavaScript example

Documentation:
- Correct header key from 'user-agent' to 'User-Agent' in the JavaScript example
- Remove an extraneous line and blank line in the README under the JavaScript section