### PR TITLE
_

### DIFF
--- a/Ryzenth/new_helper/_gemini_chats.py
+++ b/Ryzenth/new_helper/_gemini_chats.py
@@ -88,9 +88,9 @@ class ChatsGeminiAsync:
                     "model": model,
                     "messages": messages,
                     "reasoning_effort": reasoning_effort,
-                    "extra_body": extra_body,
                     "stream": stream,
-                    "tools": tools
+                    **({"extra_body": extra_body} if extra_body is not None else {}),
+                    **({"tools": tools} if tools is not None else {})
                 },
                 use_type=ResponseType.JSON
             )


### PR DESCRIPTION
## Summary by Sourcery

Conditionally include `extra_body` and `tools` in the request payload only when they are provided

Enhancements:
- Omit `extra_body` from the JSON body if it is None
- Omit `tools` from the JSON body if it is None