### PR TITLE
_

### DIFF
--- a/Ryzenth/new_helper/_openai_chats.py
+++ b/Ryzenth/new_helper/_openai_chats.py
@@ -93,7 +93,9 @@ class ChatsOpenAIAsync:
                 self.logger.warning("Default 'instructions' this warning just ignore")
 
             if reasoning is not None:
-                self.logger.warning("Default 'reasoning' this warning just ignore")
+                self.logger.warning(
+                    "'reasoning' parameter was provided but is not used in this context. No action is required; this is informational only."
+                )
 
             return ResponseResult(client=client, response=response)
         except Exception as e:

--- a/Ryzenth/new_helper/_openai_chats.py
+++ b/Ryzenth/new_helper/_openai_chats.py
@@ -89,6 +89,12 @@ class ChatsOpenAIAsync:
             if not response:
                 raise EmptyResponseError("Empty response from chat completion API")
 
+            if instructions is not None:
+                self.logger.warning("Default 'instructions' this warning just ignore")
+
+            if reasoning is not None:
+                self.logger.warning("Default 'reasoning' this warning just ignore")
+
             return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"OpenAI chats failed: {e}")

--- a/Ryzenth/new_helper/_qwen_images.py
+++ b/Ryzenth/new_helper/_qwen_images.py
@@ -68,7 +68,10 @@ class ImagesQwenAsync:
         timeout: Union[int, float] = 100,
         function_call: str = "stylization_all",
         strength: Union[int, float] = 0.5,
-        **parameters,
+        top_scale: Union[int, float] = None,
+        bottom_scale: Union[int, float] = None,
+        left_scale: Union[int, float] = None,
+        right_scale: Union[int, float] = None,
     ) -> GeneratedImageOrVideo:
 
         ALLOWED_FUNCTION_CALL = [
@@ -104,7 +107,10 @@ class ImagesQwenAsync:
                     "parameters": {
                         "n": 1,
                         "strength": strength,
-                        **parameters
+                        **({"top_scale": top_scale} if top_scale is not None else {}),
+                        **({"bottom_scale": bottom_scale} if bottom_scale is not None else {}),
+                        **({"left_scale": left_scale} if left_scale is not None else {}),
+                        **({"right_scale": right_scale} if right_scale is not None else {})
                     }
                 },
                 use_type=ResponseType.JSON
@@ -112,6 +118,9 @@ class ImagesQwenAsync:
 
             if not response:
                 raise EmptyResponseError("Empty response from image edit generation API")
+
+            if strength is not None:
+                self.logger.warning("Use 'strength' work this warning just ignore")
 
             return GeneratedImageOrVideo(client=client, content=response)
         except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

Add optional directional scaling parameters to the Qwen image editing function and warn about ignored parameters in both image editing and chat endpoints

New Features:
- Introduce top_scale, bottom_scale, left_scale, and right_scale arguments to the to_edit function for image editing

Enhancements:
- Conditionally include provided edge scale parameters in image editing requests
- Log warnings when deprecated or no-op parameters (‘strength’ in image edits and ‘instructions’ or ‘reasoning’ in chat completions) are passed