### PR TITLE
_

### DIFF
--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -31,7 +31,7 @@ from ._thinking import WhatAsync, WhatSync
 
 class Helpers:
     @classmethod
-    def encode_image_base64(cls, image_path):
+    def encode_image_base64(image_path):
         try:
             with open(image_path, "rb") as image_file:
                 return base64.b64encode(image_file.read()).decode('utf-8')

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -34,7 +34,7 @@ class ChatOrgAsync:
         self.parent = parent
         self._client = None
         self.msg = RyzenthMessage
-        self.create_upload_to = Helpers
+        self.file = Helpers
         self.logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}")
 


### PR DESCRIPTION
## Summary by Sourcery

Simplify helper API by removing an unused classmethod parameter and align attribute naming in the default chats module

Enhancements:
- Remove the unused cls parameter from encode_image_base64 to make it a simple function
- Rename the create_upload_to attribute to file in the default chats helper for clearer intent