### PR TITLE
_

### DIFF
--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -31,13 +31,21 @@ from ._thinking import WhatAsync, WhatSync
 
 class Helpers:
     @classmethod
-    def encode_image_base64(image_path):
+    def encode_image_base64(cls, image_path):
         try:
             with open(image_path, "rb") as image_file:
                 return base64.b64encode(image_file.read()).decode('utf-8')
         except FileNotFoundError:
             return None
 
+class HelpersUseStatic:
+    @staticmethod
+    def encode_image_base64(image_path):
+        try:
+            with open(image_path, "rb") as image_file:
+                return base64.b64encode(image_file.read()).decode('utf-8')
+        except FileNotFoundError:
+            return None
 
 def to_buffer(
         response=None,
@@ -79,5 +87,6 @@ __all__ = [
     "AutoRetry",
     "to_buffer",
     "Helpers",
+    "HelpersUseStatic",
     "ResponseFileImage"
 ]

--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -38,6 +38,7 @@ class Helpers:
         except FileNotFoundError:
             return None
 
+
 class HelpersUseStatic:
     @staticmethod
     def encode_image_base64(image_path):
@@ -46,6 +47,7 @@ class HelpersUseStatic:
                 return base64.b64encode(image_file.read()).decode('utf-8')
         except FileNotFoundError:
             return None
+
 
 def to_buffer(
         response=None,

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -25,7 +25,7 @@ from .._client import RyzenthApiClient
 from .._errors import InvalidMessageError, WhatFuckError
 from .._export_class import ResponseResult
 from ..enums import ResponseType
-from ..helper import AutoRetry, Helpers
+from ..helper import AutoRetry, HelpersUseStatic
 from ._models import RyzenthMessage
 
 
@@ -34,7 +34,7 @@ class ChatOrgAsync:
         self.parent = parent
         self._client = None
         self.msg = RyzenthMessage
-        self.file = Helpers
+        self.file = HelpersUseStatic
         self.logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}")
 


### PR DESCRIPTION
## Summary by Sourcery

Add a static image encoding helper alongside the existing class method and update default chats to use it

Enhancements:
- Add encode_image_base64 class method to Helpers with FileNotFoundError handling
- Introduce HelpersUseStatic with a static encode_image_base64 method and export it
- Update DefaultChats to use HelpersUseStatic for file handling