### PR TITLE
_

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://makeapullrequest.com)
 [![Ryzenth - Version](https://img.shields.io/pypi/v/Ryzenth?style=round)](https://pypi.org/project/Ryzenth)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/TeamKillerX/Ryzenth/dev.svg)](https://results.pre-commit.ci/latest/github/TeamKillerX/Ryzenth/dev)
-[![Pylint](https://github.com/TeamKillerX/Ryzenth/actions/workflows/pylint.yml/badge.svg?branch=dev)](https://github.com/TeamKillerX/Ryzenth/actions/workflows/pylint.yml)
 
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ results = await chat.ask(
         chat.msg.core("You are a helpful assistant"),
         chat.msg.user_and_image(
             "What's in this picture?",
-            chat.file.encode_image_base64("examples/path/create.jpg"),
+            "data:image/jpeg;base64," + chat.file.encode_image_base64("examples/path/create.jpg"),
             use_legacy_format=True
         )
     ],

--- a/Ryzenth/__version__.py
+++ b/Ryzenth/__version__.py
@@ -5,7 +5,7 @@ def get_user_agent() -> str:
     return f"Ryzenth/Python-{platform.python_version()}"
 
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 __author__ = "TeamKillerX"
 __title__ = "Ryzenth"
 __description__ = "Ryzenth is a flexible Multi-API SDK with built-in support for API key management and database integration."


### PR DESCRIPTION
## Summary by Sourcery

Update the example image encoding in the documentation, remove an outdated CI badge, and bump the project version to 2.3.3

Documentation:
- Remove outdated Pylint badge from the README
- Prefix base64-encoded images with the correct data URI scheme in the example

Chores:
- Bump package version to 2.3.3