### PR TITLE
_

### DIFF
--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -19,6 +19,7 @@
 
 import json
 
+
 class WhatFuckError(Exception):
     pass
 

--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -19,78 +19,71 @@
 
 import json
 
-
 class WhatFuckError(Exception):
     pass
-
 
 class EmptyResponseError(Exception):
     pass
 
-
 class EmptyMessageError(Exception):
     pass
-
 
 class InvalidMessageError(Exception):
     pass
 
-
 class InvalidFunctionCallError(Exception):
     pass
-
 
 class ParamsRequiredError(ValueError):
     pass
 
-
 class ForbiddenError(Exception):
-    """Custom exception for 403 Forbidden"""
-
+    pass
 
 class ToolNotFoundError(Exception):
-    """Raised when a base URL for a requested tool cannot be found."""
-
+    pass
 
 class RateLimitError(Exception):
     pass
 
-
 class BadRequestError(Exception):
     pass
-
 
 class AuthenticationError(Exception):
     pass
 
-
 class InternalServerError(Exception):
-    """Custom exception for 500 Error"""
-
+    pass
 
 class RequiredError(ValueError):
     pass
 
-
 class InvalidModelError(ValueError):
     pass
-
 
 class UnauthorizedAccessError(ValueError):
     pass
 
-
 class InvalidVersionError(ValueError):
     pass
-
 
 class InvalidJSONDecodeError(json.decoder.JSONDecodeError):
     pass
 
-
 class InvalidEmptyError(ValueError):
     pass
 
+class InternalServerMetaLlamaError(Exception):
+    pass
+
+class InternalServerKimiError(Exception):
+    pass
+
+class InternalServerUltimateError(Exception):
+    pass
+
+class InitializeAPIError(Exception):
+    pass
 
 async def AsyncStatusError(resp, status_httpx=False):
     if status_httpx:
@@ -213,13 +206,16 @@ def SyncStatusError(resp, status_httpx=False):
             "Status 503: Slow Down or The engine is currently overloaded, please try again later"
         )
 
-
 __all__ = [
     "WhatFuckError",
     "EmptyResponseError",
     "EmptyMessageError",
     "ForbiddenError",
     "InternalServerError",
+    "InternalServerMetaLlamaError",
+    "InternalServerKimiError",
+    "InternalServerUltimateError",
+    "InitializeAPIError",
     "AuthenticationError",
     "RateLimitError",
     "ToolNotFoundError",

--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -82,6 +82,9 @@ class InternalServerKimiError(Exception):
 class InternalServerUltimateError(Exception):
     pass
 
+class InternalServerCohereError(Exception):
+    pass
+
 class InitializeAPIError(Exception):
     pass
 

--- a/Ryzenth/new_helper/_cohere_chats.py
+++ b/Ryzenth/new_helper/_cohere_chats.py
@@ -24,7 +24,13 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    WhatFuckError,
+    AuthenticationError,
+    InitializeAPIError,
+    EmptyMessageError
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +55,7 @@ class ChatsCohereAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Cohere client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -65,7 +71,7 @@ class ChatsCohereAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -80,9 +86,9 @@ class ChatsCohereAsync:
         connectors: List[Dict] = None,
     ) -> ResponseResult:
         if not isinstance(prompt, str):
-            raise WhatFuckError("Prompt must be a string")
+            raise EmptyMessageError("Prompt must be a string")
         if not prompt.strip():
-            raise WhatFuckError("Prompt cannot be empty")
+            raise EmptyMessageError("Prompt cannot be empty")
 
         try:
             async with self._get_client() as client:
@@ -103,7 +109,7 @@ class ChatsCohereAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Cohere chats failed: {e}")
-            raise WhatFuckError(f"Cohere chats failed: {e}") from e
+            raise InternalServerCohereError(f"Cohere chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_cohere_chats.py
+++ b/Ryzenth/new_helper/_cohere_chats.py
@@ -25,11 +25,11 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
-    EmptyResponseError,
-    WhatFuckError,
     AuthenticationError,
+    EmptyMessageError,
+    EmptyResponseError,
     InitializeAPIError,
-    EmptyMessageError
+    WhatFuckError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -23,15 +23,15 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
-    InvalidMessageError,
+    AuthenticationError,
     EmptyMessageError,
-    WhatFuckError,
     InitializeAPIError,
-    InternalServerMetaLlamaError,
-    InternalServerKimiError,
-    InternalServerUltimateError,
     InternalServerError,
-    AuthenticationError
+    InternalServerKimiError,
+    InternalServerMetaLlamaError,
+    InternalServerUltimateError,
+    InvalidMessageError,
+    WhatFuckError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -22,7 +22,17 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import InvalidMessageError, WhatFuckError
+from .._errors import (
+    InvalidMessageError,
+    EmptyMessageError,
+    WhatFuckError,
+    InitializeAPIError,
+    InternalServerMetaLlamaError,
+    InternalServerKimiError,
+    InternalServerUltimateError,
+    InternalServerError,
+    AuthenticationError
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -48,7 +58,7 @@ class ChatOrgAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -75,7 +85,7 @@ class ChatOrgAsync:
                 return ResponseResult(client, response)
         except Exception as e:
             self.logger.error(f"chat meta llama ask failed: {e}")
-            raise WhatFuckError(f"chat meta llama ask failed: {e}") from e
+            raise InternalServerMetaLlamaError(f"chat meta llama ask failed: {e}") from e
         finally:
             pass
 
@@ -104,7 +114,7 @@ class ChatOrgAsync:
                 return ResponseResult(client, response)
         except Exception as e:
             self.logger.error(f"chat kimi ask failed: {e}")
-            raise WhatFuckError(f"chat kimi ask failed: {e}") from e
+            raise InternalServerKimiError(f"chat kimi ask failed: {e}") from e
         finally:
             pass
 
@@ -119,15 +129,15 @@ class ChatOrgAsync:
     ) -> ResponseResult:
         if isinstance(prompt, str):
             if not prompt.strip():
-                raise WhatFuckError("Prompt cannot be empty")
+                raise EmptyMessageError("Prompt cannot be empty")
         elif isinstance(prompt, list):
             if not prompt or all(
                 isinstance(
                     item,
                     dict) and not item for item in prompt):
-                raise WhatFuckError("Prompt cannot be empty")
+                raise EmptyMessageError("Prompt cannot be empty")
         else:
-            raise WhatFuckError("Prompt type is invalid")
+            raise InvalidMessageError("Prompt type is invalid")
 
         try:
             use_turbo_fast = kwargs.pop("use_turbo_fast", False)
@@ -147,7 +157,7 @@ class ChatOrgAsync:
                     auth_key = kwargs.pop("auth_key", None)
                     auth_id = kwargs.pop("auth_id", None)
                     if not all([auth_key, auth_id]):
-                        raise WhatFuckError(
+                        raise AuthenticationError(
                             "All required auth, missing 'auth_key' and 'auth_id'")
                     response = await client.post(
                         tool="ryzenth-v2",
@@ -171,7 +181,7 @@ class ChatOrgAsync:
                 return ResponseResult(client, response)
         except Exception as e:
             self.logger.error(f"chat ask failed: {e}")
-            raise WhatFuckError(f"chat ask failed: {e}") from e
+            raise InternalServerError(f"chat ask failed: {e}") from e
         finally:
             pass
 
@@ -185,9 +195,9 @@ class ChatOrgAsync:
         model: str = "grok"
     ) -> ResponseResult:
         if not prompt or not prompt.strip():
-            raise WhatFuckError("Prompt cannot be empty")
+            raise EmptyMessageError("Prompt cannot be empty")
         if not model or not model.strip():
-            raise WhatFuckError("model cannot be empty")
+            raise EmptyMessageError("model cannot be empty")
 
         try:
             async with self._get_client() as client:
@@ -201,7 +211,7 @@ class ChatOrgAsync:
                 return ResponseResult(client, response, is_ultimate=True)
         except Exception as e:
             self.logger.error(f"chat ultimate ask failed: {e}")
-            raise WhatFuckError(f"chat ultimate ask failed: {e}") from e
+            raise InternalServerUltimateError(f"chat ultimate ask failed: {e}") from e
         finally:
             pass
 


### PR DESCRIPTION
## Summary by Sourcery

Add granular error classes and refactor chat helpers to use specific exceptions instead of a catch-all error

New Features:
- Introduce new exception types for internal server errors, initialization failures, and specific chat providers

Enhancements:
- Replace generic WhatFuckError usage with context-appropriate exceptions (e.g., EmptyMessageError, AuthenticationError, InternalServerMetaLlamaError)
- Improve error handling in chat helper modules by raising specific errors during API client initialization and request failures
- Update __all__ export list to include newly added exception classes