### PR TITLE
_

### DIFF
--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -29,6 +29,9 @@ class EmptyResponseError(Exception):
 class EmptyMessageError(Exception):
     pass
 
+class EmptyModelError(Exception):
+    pass
+
 class InvalidMessageError(Exception):
     pass
 
@@ -214,6 +217,7 @@ __all__ = [
     "WhatFuckError",
     "EmptyResponseError",
     "EmptyMessageError",
+    "EmptyModelError",
     "ForbiddenError",
     "InternalServerError",
     "InternalServerMetaLlamaError",

--- a/Ryzenth/new_helper/_cohere_chats.py
+++ b/Ryzenth/new_helper/_cohere_chats.py
@@ -86,7 +86,7 @@ class ChatsCohereAsync:
         connectors: List[Dict] = None,
     ) -> ResponseResult:
         if not isinstance(prompt, str):
-            raise EmptyMessageError("Prompt must be a string")
+            raise InvalidMessageError("Prompt must be a string")
         if not prompt.strip():
             raise EmptyMessageError("Prompt cannot be empty")
 

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -25,6 +25,7 @@ from .._client import RyzenthApiClient
 from .._errors import (
     AuthenticationError,
     EmptyMessageError,
+    EmptyModelError,
     InitializeAPIError,
     InternalServerError,
     InternalServerKimiError,
@@ -32,7 +33,6 @@ from .._errors import (
     InternalServerUltimateError,
     InvalidMessageError,
     WhatFuckError,
-    EmptyModelError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -32,6 +32,7 @@ from .._errors import (
     InternalServerUltimateError,
     InvalidMessageError,
     WhatFuckError,
+    EmptyModelError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType
@@ -197,7 +198,7 @@ class ChatOrgAsync:
         if not prompt or not prompt.strip():
             raise EmptyMessageError("Prompt cannot be empty")
         if not model or not model.strip():
-            raise EmptyMessageError("model cannot be empty")
+            raise EmptyModelError("model cannot be empty")
 
         try:
             async with self._get_client() as client:


### PR DESCRIPTION
## Summary by Sourcery

Add a dedicated EmptyModelError and update error handling to use the correct exception types for invalid prompts and missing models.

Enhancements:
- Introduce EmptyModelError exception and register it in the error registry
- Change non-string prompt handling to raise InvalidMessageError in the Cohere chat helper
- Raise EmptyModelError instead of EmptyMessageError for empty model in the default chat helper