### PR TITLE
_

### DIFF
--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -113,6 +113,12 @@ class InternalServerGrokError(Exception):
 class InternalServerDeepseekError(Exception):
     pass
 
+class InternalServerOpenaiError(Exception):
+    pass
+
+class InternalServerQwenError(Exception):
+    pass
+
 class InitializeAPIError(Exception):
     pass
 
@@ -254,6 +260,8 @@ __all__ = [
     "InternalServerGeminiError",
     "InternalServerGrokError",
     "InternalServerDeepseekError",
+    "InternalServerQwenError",
+    "InternalServerOpenaiError",
     "InitializeAPIError",
     "InvalidTypeError",
     "AuthenticationError",

--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -110,6 +110,9 @@ class InternalServerGeminiError(Exception):
 class InternalServerGrokError(Exception):
     pass
 
+class InternalServerDeepseekError(Exception):
+    pass
+
 class InitializeAPIError(Exception):
     pass
 
@@ -250,6 +253,7 @@ __all__ = [
     "InternalServerClaudeError",
     "InternalServerGeminiError",
     "InternalServerGrokError",
+    "InternalServerDeepseekError",
     "InitializeAPIError",
     "InvalidTypeError",
     "AuthenticationError",

--- a/Ryzenth/_errors.py
+++ b/Ryzenth/_errors.py
@@ -119,6 +119,9 @@ class InternalServerOpenaiError(Exception):
 class InternalServerQwenError(Exception):
     pass
 
+class InternalServerZaiError(Exception):
+    pass
+
 class InitializeAPIError(Exception):
     pass
 
@@ -262,6 +265,7 @@ __all__ = [
     "InternalServerDeepseekError",
     "InternalServerQwenError",
     "InternalServerOpenaiError",
+    "InternalServerZaiError",
     "InitializeAPIError",
     "InvalidTypeError",
     "AuthenticationError",

--- a/Ryzenth/new_helper/_deepseek_chats.py
+++ b/Ryzenth/new_helper/_deepseek_chats.py
@@ -25,12 +25,12 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
-    EmptyResponseError,
-    InvalidMessageError,
     AuthenticationError,
-    WhatFuckError,
+    EmptyResponseError,
     InitializeAPIError,
     InternalServerDeepseekError,
+    InvalidMessageError,
+    WhatFuckError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_deepseek_chats.py
+++ b/Ryzenth/new_helper/_deepseek_chats.py
@@ -24,7 +24,14 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, InvalidMessageError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    InvalidMessageError,
+    AuthenticationError,
+    WhatFuckError,
+    InitializeAPIError,
+    InternalServerDeepseekError,
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +56,7 @@ class ChatsDeepseekAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Deepseek client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -64,7 +71,7 @@ class ChatsDeepseekAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -100,7 +107,7 @@ class ChatsDeepseekAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Deepseek chats failed: {e}")
-            raise WhatFuckError(f"Deepseek chats failed: {e}") from e
+            raise InternalServerDeepseekError(f"Deepseek chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_gemini_chats.py
+++ b/Ryzenth/new_helper/_gemini_chats.py
@@ -24,7 +24,14 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, InvalidMessageError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    InvalidMessageError,
+    WhatFuckError,
+    InitializeAPIError,
+    AuthenticationError,
+    InternalServerGeminiError,
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +56,7 @@ class ChatsGeminiAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Gemini client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -63,7 +70,7 @@ class ChatsGeminiAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -106,7 +113,7 @@ class ChatsGeminiAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Gemini chats failed: {e}")
-            raise WhatFuckError(f"Gemini chats failed: {e}") from e
+            raise InternalServerGeminiError(f"Gemini chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_gemini_chats.py
+++ b/Ryzenth/new_helper/_gemini_chats.py
@@ -25,12 +25,12 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
+    AuthenticationError,
     EmptyResponseError,
+    InitializeAPIError,
+    InternalServerGeminiError,
     InvalidMessageError,
     WhatFuckError,
-    InitializeAPIError,
-    AuthenticationError,
-    InternalServerGeminiError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_grok_chats.py
+++ b/Ryzenth/new_helper/_grok_chats.py
@@ -25,12 +25,12 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
+    AuthenticationError,
     EmptyResponseError,
+    InitializeAPIError,
+    InternalServerGrokError,
     InvalidMessageError,
     WhatFuckError,
-    InternalServerGrokError,
-    AuthenticationError,
-    InitializeAPIError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_grok_chats.py
+++ b/Ryzenth/new_helper/_grok_chats.py
@@ -24,7 +24,14 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, InvalidMessageError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    InvalidMessageError,
+    WhatFuckError,
+    InternalServerGrokError,
+    AuthenticationError,
+    InitializeAPIError,
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +56,7 @@ class ChatsGrokAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Grok client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -64,7 +71,7 @@ class ChatsGrokAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -100,7 +107,7 @@ class ChatsGrokAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Grok chats failed: {e}")
-            raise WhatFuckError(f"Grok chats failed: {e}") from e
+            raise InternalServerGrokError(f"Grok chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_old_gemini_chats.py
+++ b/Ryzenth/new_helper/_old_gemini_chats.py
@@ -24,7 +24,15 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyMessageError, EmptyResponseError, WhatFuckError
+from .._errors import (
+    EmptyMessageError,
+    EmptyResponseError,
+    WhatFuckError,
+    InitializeAPIError,
+    InternalServerGeminiError,
+    AuthenticationError,
+    InvalidEmptyErrorz
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry
@@ -46,7 +54,7 @@ class OldChatsGeminiAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Gemini client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -60,7 +68,7 @@ class OldChatsGeminiAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -84,7 +92,7 @@ class OldChatsGeminiAsync:
                     dict) and not item for item in messages):
                 raise EmptyMessageError("messages cannot be empty")
         else:
-            raise EmptyMessageError(
+            raise InvalidEmptyError(
                 f"messages type is invalid: received type '{type(messages).__name__}'")
 
         try:
@@ -112,7 +120,7 @@ class OldChatsGeminiAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Gemini chats failed: {e}")
-            raise WhatFuckError(f"Gemini chats failed: {e}") from e
+            raise InternalServerGeminiError(f"Gemini chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_old_gemini_chats.py
+++ b/Ryzenth/new_helper/_old_gemini_chats.py
@@ -25,13 +25,13 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
+    AuthenticationError,
     EmptyMessageError,
     EmptyResponseError,
-    WhatFuckError,
     InitializeAPIError,
     InternalServerGeminiError,
-    AuthenticationError,
-    InvalidEmptyErrorz
+    InvalidEmptyErrorz,
+    WhatFuckError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_openai_chats.py
+++ b/Ryzenth/new_helper/_openai_chats.py
@@ -24,7 +24,15 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    WhatFuckError,
+    InitializeAPIError,
+    EmptyMessageError,
+    BadRequestError,
+    AuthenticationError,
+    InternalServerOpenaiError,
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +57,7 @@ class ChatsOpenAIAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for openAI client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -63,7 +71,7 @@ class ChatsOpenAIAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -79,7 +87,7 @@ class ChatsOpenAIAsync:
         instructions: str = None,
     ) -> ResponseResult:
         if not prompt:
-            raise WhatFuckError("Prompt is Required")
+            raise BadRequestError("Prompt is Required")
 
         try:
             async with self._get_client() as client:
@@ -101,7 +109,7 @@ class ChatsOpenAIAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"OpenAI chats failed: {e}")
-            raise WhatFuckError(f"OpenAI chats failed: {e}") from e
+            raise InternalServerOpenaiError(f"OpenAI chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_openai_chats.py
+++ b/Ryzenth/new_helper/_openai_chats.py
@@ -25,13 +25,13 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
-    EmptyResponseError,
-    WhatFuckError,
-    InitializeAPIError,
-    EmptyMessageError,
-    BadRequestError,
     AuthenticationError,
+    BadRequestError,
+    EmptyMessageError,
+    EmptyResponseError,
+    InitializeAPIError,
     InternalServerOpenaiError,
+    WhatFuckError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_qwen_chats.py
+++ b/Ryzenth/new_helper/_qwen_chats.py
@@ -25,12 +25,12 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
+    AuthenticationError,
     EmptyResponseError,
+    InitializeAPIError,
+    InternalServerQwenError,
     InvalidMessageError,
     WhatFuckError,
-    InternalServerQwenError,
-    InitializeAPIError,
-    AuthenticationError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_qwen_chats.py
+++ b/Ryzenth/new_helper/_qwen_chats.py
@@ -24,7 +24,14 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, InvalidMessageError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    InvalidMessageError,
+    WhatFuckError,
+    InternalServerQwenError,
+    InitializeAPIError,
+    AuthenticationError,
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +56,7 @@ class ChatsQwenAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Alibaba client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -64,7 +71,7 @@ class ChatsQwenAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -106,7 +113,7 @@ class ChatsQwenAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Qwen chats failed: {e}")
-            raise WhatFuckError(f"Qwen chats failed: {e}") from e
+            raise InternalServerQwenError(f"Qwen chats failed: {e}") from e
         finally:
             pass
 

--- a/Ryzenth/new_helper/_zai_chats.py
+++ b/Ryzenth/new_helper/_zai_chats.py
@@ -25,12 +25,12 @@ from typing import Dict, List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
-    EmptyResponseError,
-    InvalidMessageError,
-    WhatFuckError,
     AuthenticationError,
+    EmptyResponseError,
     InitializeAPIError,
     InternalServerZaiError,
+    InvalidMessageError,
+    WhatFuckError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_zai_chats.py
+++ b/Ryzenth/new_helper/_zai_chats.py
@@ -24,7 +24,14 @@ from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
-from .._errors import EmptyResponseError, InvalidMessageError, WhatFuckError
+from .._errors import (
+    EmptyResponseError,
+    InvalidMessageError,
+    WhatFuckError,
+    AuthenticationError,
+    InitializeAPIError,
+    InternalServerZaiError,
+)
 from .._export_class import ResponseResult
 from ..enums import ResponseType
 from ..helper import AutoRetry, HelpersUseStatic
@@ -49,7 +56,7 @@ class ChatsZaiAsync:
 
             if not api_key or not isinstance(
                     api_key, str) or not api_key.strip():
-                raise WhatFuckError(
+                raise AuthenticationError(
                     "Missing or invalid API key for Zai client initialization.")
             try:
                 self._client = RyzenthApiClient(
@@ -65,7 +72,7 @@ class ChatsZaiAsync:
                     use_default_headers=True
                 )
             except Exception as e:
-                raise WhatFuckError(
+                raise InitializeAPIError(
                     f"Failed to initialize API client: {e}") from e
         return self._client
 
@@ -105,7 +112,7 @@ class ChatsZaiAsync:
                 return ResponseResult(client=client, response=response)
         except Exception as e:
             self.logger.error(f"Zai chats failed: {e}")
-            raise WhatFuckError(f"Zai chats failed: {e}") from e
+            raise InternalServerZaiError(f"Zai chats failed: {e}") from e
         finally:
             pass
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce specific exception types for various chat services and replace generic error raises with more descriptive, typed exceptions across chat helper modules.

Enhancements:
- Add InternalServerDeepseekError, InternalServerOpenaiError, InternalServerQwenError, and InternalServerZaiError and register them in SyncStatusError.
- Replace generic WhatFuckError in chat helper modules with AuthenticationError for missing API keys, InitializeAPIError for client initialization failures, BadRequestError for missing prompts, InvalidEmptyError for empty message arrays, and InternalServerXError for service call failures.