### PR TITLE
_

### DIFF
--- a/Ryzenth/new_helper/_default_images.py
+++ b/Ryzenth/new_helper/_default_images.py
@@ -145,7 +145,7 @@ class ImagesOrgAsync:
                     tool="ryzenth-v2",
                     path="/api/v1/openai-imagen",
                     timeout=timeout,
-                    json={"input": prompt},
+                    json={"input": prompt.strip()},
                     use_type=ResponseType.JSON
                 )
                 if not response:
@@ -175,7 +175,7 @@ class ImagesOrgAsync:
                     tool="ryzenth-v2",
                     path="/api/v1/openai-imagen/turn-text",
                     timeout=timeout,
-                    json={"input": prompt},
+                    json={"input": prompt.strip()},
                     use_type=ResponseType.JSON
                 )
                 if not response:


### PR DESCRIPTION
## Summary by Sourcery

Trim leading and trailing whitespace from prompts before sending image generation requests to the OpenAI endpoints

Bug Fixes:
- Strip whitespace from the prompt in create_openai before JSON payload
- Strip whitespace from the prompt in create_openai_and_captions before JSON payload