### PR TITLE
_

### DIFF
--- a/Ryzenth/types/__init__.py
+++ b/Ryzenth/types/__init__.py
@@ -58,7 +58,7 @@ class MakeFetch(BaseModel):
     post: bool = False
     head: bool = False
     headers: Optional[dict] = None
-    evaluate: bool = False
+    evaluate: Optional[Callable] = None
     object_flag: bool = False
     return_json: bool = False
     return_content: bool = False

--- a/Ryzenth/types/__init__.py
+++ b/Ryzenth/types/__init__.py
@@ -55,11 +55,11 @@ class RequestHumanizer(BaseModel):
 
 class MakeFetch(BaseModel):
     url: str
-    post: Optional[bool] = False
-    head: Optional[bool] = False
+    post: bool = False
+    head: bool = False
     headers: Optional[dict] = None
-    evaluate: Optional[str] = None
-    object_flag: Optional[bool] = False
-    return_json: Optional[bool] = False
-    return_content: Optional[bool] = False
-    return_json_and_obj: Optional[bool] = False
+    evaluate: bool = False
+    object_flag: bool = False
+    return_json: bool = False
+    return_content: bool = False
+    return_json_and_obj: bool = False


### PR DESCRIPTION
## Summary by Sourcery

Tighten the type definitions in the MakeFetch model by making boolean fields non-optional and updating the evaluate field to accept callables.

Enhancements:
- Simplify MakeFetch boolean flags by using non-optional bool types
- Change evaluate field type in MakeFetch from Optional[str] to Optional[Callable]