### PR TITLE
_

### DIFF
--- a/Ryzenth/__version__.py
+++ b/Ryzenth/__version__.py
@@ -5,7 +5,7 @@ def get_user_agent() -> str:
     return f"Ryzenth/Python-{platform.python_version()}"
 
 
-__version__ = "2.3.7"
+__version__ = "2.3.8"
 __author__ = "TeamKillerX"
 __title__ = "Ryzenth"
 __description__ = "Ryzenth is a flexible Multi-API SDK with built-in support for API key management and database integration."

--- a/Ryzenth/new_helper/_default_images.py
+++ b/Ryzenth/new_helper/_default_images.py
@@ -164,7 +164,7 @@ class ImagesOrgAsync:
         self,
         prompt: str,
         *,
-        enabled_format_url: bool = False,
+        enabled_format_url: str = "false",
         timeout: Union[int, float] = 100
     ) -> GeneratedImageOrVideo:
         if not prompt or not prompt.strip():


### PR DESCRIPTION
## Summary by Sourcery

Bump package version to 2.3.8 and update the default type of the enabled_format_url parameter in the image generation helper to a string

Enhancements:
- Change enabled_format_url parameter type from bool to str with default "false" in create_openai_and_captions

Chores:
- Bump package version from 2.3.7 to 2.3.8