### PR TITLE
__

### DIFF
--- a/Ryzenth/new_helper/_default_images.py
+++ b/Ryzenth/new_helper/_default_images.py
@@ -24,12 +24,12 @@ from typing import List, Union
 from .._benchmark import Benchmark
 from .._client import RyzenthApiClient
 from .._errors import (
+    BadRequestError,
     EmptyMessageError,
     EmptyResponseError,
     InitializeAPIError,
     InternalServerError,
     WhatFuckError,
-    BadRequestError,
 )
 from .._export_class import GeneratedImageOrVideo, ResponseResult
 from ..enums import ResponseType

--- a/Ryzenth/new_helper/_default_images.py
+++ b/Ryzenth/new_helper/_default_images.py
@@ -29,6 +29,7 @@ from .._errors import (
     InitializeAPIError,
     InternalServerError,
     WhatFuckError,
+    BadRequestError,
 )
 from .._export_class import GeneratedImageOrVideo, ResponseResult
 from ..enums import ResponseType
@@ -160,14 +161,15 @@ class ImagesOrgAsync:
 
     @Benchmark.performance(level=logging.DEBUG)
     @AutoRetry(max_retries=3, delay=1.5)
-    async def create_openai_to_ghibli_edit(
+    async def create_ghibli_to_edit(
         self,
         file_path: str,
         *,
+        style: str = "ghibli.default",
         timeout: Union[int, float] = 100
     ) -> GeneratedImageOrVideo:
         if not file_path:
-            file_path = "default.jpg"
+            raise BadRequestError("Required file_path")
 
         try:
             async with self._get_client() as client:


### PR DESCRIPTION
## Summary by Sourcery

Refactor and improve the Ghibli image editing helper by renaming the method, introducing a customizable style parameter, and tightening input validation.

Enhancements:
- Rename image editing helper from create_openai_to_ghibli_edit to create_ghibli_to_edit
- Add configurable 'style' parameter defaulting to 'ghibli.default' for image edits
- Enforce file_path presence by raising BadRequestError instead of defaulting to 'default.jpg'