### PR TITLE
_

### DIFF
--- a/Ryzenth/_callbody/_call_image_gemini_edit.py
+++ b/Ryzenth/_callbody/_call_image_gemini_edit.py
@@ -36,10 +36,6 @@ class ImagesGeminiEdit:
         return self
 
     @property
-    def to(self):
-        return self
-
-    @property
     def edit(self):
         return self
 

--- a/Ryzenth/_callbody/_call_image_gemini_edit.py
+++ b/Ryzenth/_callbody/_call_image_gemini_edit.py
@@ -32,7 +32,7 @@ class ImagesGeminiEdit:
         self.parent = parent
 
     @property
-    def gemini(self):
+    def run(self):
         return self
 
     @property

--- a/Ryzenth/_callbody/_call_image_ghibli.py
+++ b/Ryzenth/_callbody/_call_image_ghibli.py
@@ -36,10 +36,6 @@ class ImagesGhibliFromOpenAI:
         return self
 
     @property
-    def to(self):
-        return self
-
-    @property
     def edit(self):
         return self
 

--- a/Ryzenth/_callbody/_call_image_vision.py
+++ b/Ryzenth/_callbody/_call_image_vision.py
@@ -36,10 +36,6 @@ class ImagesVision:
         return self
 
     @property
-    def to(self):
-        return self
-
-    @property
     def ask(self):
         return self
 


### PR DESCRIPTION
## Summary by Sourcery

Simplify image call classes by removing redundant chaining properties and converting run to a method in the GeminiEdit call

Enhancements:
- Remove the gemini and to properties from the GeminiEdit image call
- Convert run in the GeminiEdit image call from a property to a method
- Remove the to property from the Ghibli and Vision image call classes