### PR TITLE
_

### DIFF
--- a/Ryzenth/_callbody/_call_image_turntext_gemini.py
+++ b/Ryzenth/_callbody/_call_image_turntext_gemini.py
@@ -36,10 +36,6 @@ class ImagesTurnTextGemini:
         return self
 
     @property
-    def captions(self):
-        return self
-
-    @property
     def run(self):
         return self
 

--- a/Ryzenth/_callbody/_call_image_turntext_openai.py
+++ b/Ryzenth/_callbody/_call_image_turntext_openai.py
@@ -36,10 +36,6 @@ class ImagesTurnTextOpenAI:
         return self
 
     @property
-    def captions(self):
-        return self
-
-    @property
     def run(self):
         return self
 

--- a/Ryzenth/_callbody/_call_image_vision.py
+++ b/Ryzenth/_callbody/_call_image_vision.py
@@ -36,7 +36,7 @@ class ImagesVision:
         return self
 
     @property
-    def run(self):
+    def ask(self):
         return self
 
     @Benchmark.performance(level=logging.DEBUG)

--- a/Ryzenth/new_helper/_default_images.py
+++ b/Ryzenth/new_helper/_default_images.py
@@ -78,11 +78,11 @@ class ImagesOrgAsync:
         return ImagesOpenAI(self)
 
     @property
-    def same_openai(self):
+    def captions_openai(self):
         return ImagesTurnTextOpenAI(self)
 
     @property
-    def same_gemini(self):
+    def captions_gemini(self):
         return ImagesTurnTextGemini(self)
 
     @Benchmark.performance(level=logging.DEBUG)


### PR DESCRIPTION
## Summary by Sourcery

Standardize and improve naming consistency across image captioning and vision call interfaces

Enhancements:
- Remove redundant captions property from Gemini and OpenAI image-to-text call bodies
- Rename default_images helper properties same_openai and same_gemini to captions_openai and captions_gemini
- Rename the run property to ask in the image vision call body