### PR TITLE
_

### DIFF
--- a/Ryzenth/_callbody/_call_image_gemini_edit.py
+++ b/Ryzenth/_callbody/_call_image_gemini_edit.py
@@ -73,3 +73,5 @@ class ImagesGeminiEdit:
         except Exception as e:
             self.parent.logger.error(f"Gemini Image generation failed: {e}")
             raise InternalServerError(f"Gemini Image generation failed: {e}") from e
+        finally:
+            pass

--- a/Ryzenth/_callbody/_call_image_openai.py
+++ b/Ryzenth/_callbody/_call_image_openai.py
@@ -62,3 +62,5 @@ class ImagesOpenAI:
         except Exception as e:
             self.parent.logger.error(f"OpenAI Image generation failed: {e}")
             raise InternalServerError(f"OpenAI Image generation failed: {e}") from e
+        finally:
+            pass

--- a/Ryzenth/_callbody/_call_image_turntext_gemini.py
+++ b/Ryzenth/_callbody/_call_image_turntext_gemini.py
@@ -66,3 +66,5 @@ class ImagesTurnTextGemini:
         except Exception as e:
             self.parent.logger.error(f"Gemini Image generation failed: {e}")
             raise InternalServerError(f"Gemini Image generation failed: {e}") from e
+        finally:
+            pass

--- a/Ryzenth/_callbody/_call_image_turntext_openai.py
+++ b/Ryzenth/_callbody/_call_image_turntext_openai.py
@@ -70,3 +70,5 @@ class ImagesTurnTextOpenAI:
         except Exception as e:
             self.parent.logger.error(f"OpenAI Image generation failed: {e}")
             raise InternalServerError(f"OpenAI Image generation failed: {e}") from e
+        finally:
+            pass

--- a/Ryzenth/_callbody/_call_image_vision.py
+++ b/Ryzenth/_callbody/_call_image_vision.py
@@ -64,3 +64,5 @@ class ImagesVision:
         except Exception as e:
             self.parent.logger.error(f"Image vision failed: {e}")
             raise InternalServerError(f"Image vision failed: {e}") from e
+        finally:
+            pass


### PR DESCRIPTION
## Summary by Sourcery

Add empty finally blocks to all image call handler methods to standardize exception handling structure across modules.

Enhancements:
- Insert a no-op finally clause in Gemini and OpenAI image generation handlers
- Insert a no-op finally clause in turntext handlers for Gemini and OpenAI
- Insert a no-op finally clause in the image vision handler