### PR TITLE
_

### DIFF
--- a/Ryzenth/new_helper/_default_images.py
+++ b/Ryzenth/new_helper/_default_images.py
@@ -48,6 +48,7 @@ class ImagesOrgAsync:
     def __init__(self, parent):
         self.parent = parent
         self._client = None
+        self.model_ultra_toggle = "disabled"
         self.request = HelpersUseStatic
         self.logger = logging.getLogger(
             f"{__name__}.{self.__class__.__name__}")
@@ -57,7 +58,7 @@ class ImagesOrgAsync:
             try:
                 self._client = RyzenthApiClient(
                     tools_name=["ryzenth-v2"],
-                    api_key={"ryzenth-v2": [{}]},
+                    api_key={"ryzenth-v2": [{"X-UltraPlus-Async": self.model_ultra_toggle}]},
                     rate_limit=100,
                     use_default_headers=True
                 )


### PR DESCRIPTION
## Summary by Sourcery

Introduce a toggle for UltraPlus asynchronous behavior in the default images helper by adding a model_ultra_toggle attribute and passing it as the X-UltraPlus-Async header to the API client.

Enhancements:
- Add model_ultra_toggle attribute to ImagesOrgAsync with default "disabled"
- Include X-UltraPlus-Async header based on model_ultra_toggle when constructing RyzenthApiClient