### PR TITLE
_

### DIFF
--- a/Ryzenth/helper/__init__.py
+++ b/Ryzenth/helper/__init__.py
@@ -72,13 +72,13 @@ class HelpersUseStatic:
 def to_buffer(
     response=None,
     filename="default.jpg",
-    return_image_base64=False
+    return_default_base64=False
 ):
-    allowed_extensions = (".jpg", ".jpeg", ".png", ".gif")
+    allowed_extensions = (".jpg", ".jpeg", ".png", ".gif", ".mp4")
     if not filename.lower().endswith(allowed_extensions):
         return None
     with open(filename, "wb") as f:
-        if return_image_base64:
+        if return_default_base64:
             if not response:
                 return None
             try:


### PR DESCRIPTION
## Summary by Sourcery

Enhance the to_buffer helper by renaming a parameter for clarity and adding MP4 support

Enhancements:
- Rename return_image_base64 parameter to return_default_base64
- Include .mp4 in the list of allowed extensions in to_buffer