### PR TITLE
$

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,6 @@ print(await results.to_dict())
 - `https://api.ryzenths.dpdns.org/api/v1/chat/completions`
 - `https://api.ryzenths.dpdns.org/api/v1/responses`
 
-### Frequently Asked Questions
->
-> **Is there a free trial for unlimited?**
->
-> Yes! All free versions come with a free trial, no credit card required.
->
 You can use source code [OpenAI Python SDK on GitHub](https://github.com/openai/openai-python) or [OpenAI Javascript SDK on GitHub](https://github.com/openai/openai-node)
 
 **List Models:**
@@ -127,7 +121,7 @@ Javascript Code
 import OpenAI from 'openai';
 
 const clients = new OpenAI({
-  apiKey: "ryzenth-free",
+  apiKey: "apikey-required",
   baseURL: "https://api.ryzenths.dpdns.org/api/v1"
 });
 

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import os
 from typing import Dict, List, Union
 
 from .._benchmark import Benchmark
@@ -34,6 +35,7 @@ from .._errors import (
     InvalidMessageError,
     InvalidTypeError,
     WhatFuckError,
+    AuthenticationError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType
@@ -52,10 +54,21 @@ class ChatOrgAsync:
 
     def _get_client(self) -> RyzenthApiClient:
         if self._client is None:
+            api_key = getattr(
+                self.parent,
+                "_api_key",
+                None) or os.environ.get("RYZENTH_API_KEY")
+
+            if not api_key or not isinstance(
+                    api_key, str) or not api_key.strip():
+                raise AuthenticationError(
+                    "Missing or invalid API key for Ryzenth client initialization.")
             try:
                 self._client = RyzenthApiClient(
                     tools_name=["ryzenth-v2"],
-                    api_key={"ryzenth-v2": [{}]},
+                    api_key={"ryzenth-v2": [{
+                        "Authorization": f"Bearer {api_key}"
+                    }]},
                     rate_limit=100,
                     use_default_headers=True
                 )

--- a/Ryzenth/new_helper/_default_chats.py
+++ b/Ryzenth/new_helper/_default_chats.py
@@ -35,7 +35,6 @@ from .._errors import (
     InvalidMessageError,
     InvalidTypeError,
     WhatFuckError,
-    AuthenticationError,
 )
 from .._export_class import ResponseResult
 from ..enums import ResponseType


### PR DESCRIPTION
## Summary by Sourcery

Enforce API key validation for Ryzenth client initialization with proper bearer authorization and clean up README by removing outdated FAQ and updating example credentials

Enhancements:
- Require a valid API key from parent attribute or RYZENTH_API_KEY environment variable before initializing the client
- Inject the API key as a Bearer token in the RyzenthApiClient authorization header and raise AuthenticationError on invalid or missing key

Documentation:
- Remove the outdated FAQ section about free trial
- Update the JavaScript example to use a placeholder for the required API key